### PR TITLE
Vis popup nedover

### DIFF
--- a/frontend/src/komponenter/Klagebehandling/Behandlingsskjema/AutolagreElement.tsx
+++ b/frontend/src/komponenter/Klagebehandling/Behandlingsskjema/AutolagreElement.tsx
@@ -38,7 +38,7 @@ const LagringsIndikator = (props: Props) => {
       <Popover
         ankerEl={anker}
         onRequestClose={() => setAnker(undefined)}
-        orientering={PopoverOrientering.OverHoyre}
+        orientering={PopoverOrientering.UnderHoyre}
       >
         <p style={{ padding: "16px" }}>Endringene lagres automatisk.</p>
       </Popover>


### PR DESCRIPTION
https://trello.com/c/ww1mtfF1/220-pop-up-info-tekst-til-lagringsindikator-vises-delvis-utenfor-skjermen