### PR TITLE
Fiks dokumenter vedlegg

### DIFF
--- a/api-mock-server/package-lock.json
+++ b/api-mock-server/package-lock.json
@@ -36,6 +36,7 @@
         "@types/node": "^14.14.7",
         "@types/ramda": "^0.27.32",
         "@types/source-map-support": "^0.5.3",
+        "@types/sqlite3": "^3.1.7",
         "jest": "^26.6.3",
         "nodemon": "^2.0.6",
         "onchange": "^7.1.0",
@@ -1300,6 +1301,15 @@
       "dev": true,
       "dependencies": {
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/@types/sqlite3": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/sqlite3/-/sqlite3-3.1.7.tgz",
+      "integrity": "sha512-8FHV/8Uzd7IwdHm5mvmF2Aif4aC/gjrt4axWD9SmfaxITnOjtOhCbOSTuqv/VbH1uq0QrwlaTj9aTz3gmR6u4w==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -10065,6 +10075,15 @@
       "dev": true,
       "requires": {
         "source-map": "^0.6.0"
+      }
+    },
+    "@types/sqlite3": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/sqlite3/-/sqlite3-3.1.7.tgz",
+      "integrity": "sha512-8FHV/8Uzd7IwdHm5mvmF2Aif4aC/gjrt4axWD9SmfaxITnOjtOhCbOSTuqv/VbH1uq0QrwlaTj9aTz3gmR6u4w==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@types/stack-utils": {

--- a/api-mock-server/package.json
+++ b/api-mock-server/package.json
@@ -11,6 +11,9 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
+  "prettier": {
+    "printWidth": 100
+  },
   "dependencies": {
     "@tinyhttp/app": "^1.0.3",
     "@tinyhttp/cors": "^1.2.5",
@@ -39,6 +42,7 @@
     "@types/node": "^14.14.7",
     "@types/ramda": "^0.27.32",
     "@types/source-map-support": "^0.5.3",
+    "@types/sqlite3": "^3.1.7",
     "jest": "^26.6.3",
     "nodemon": "^2.0.6",
     "onchange": "^7.1.0",

--- a/api-mock-server/scripts/lagDokumenter.rb
+++ b/api-mock-server/scripts/lagDokumenter.rb
@@ -1,5 +1,3 @@
-# generer 51 tilfeldige oppgaver
-
 require 'json'
 require 'faker'
 require 'sqlite3'
@@ -8,25 +6,16 @@ def init()
     begin
         db = SQLite3::Database.open ARGV[0]
         db.execute "DROP TABLE IF EXISTS Dokumenter"
-        db.execute "DROP TABLE IF EXISTS Vedlegg"
 
         db.execute "CREATE TABLE Dokumenter
             (
-            	journalpostId TEXT PRIMARY KEY,
-            	dokumentInfoId TEXT,
+            	journalpostId TEXT NOT NULL,
+            	dokumentInfoId TEXT NOT NULL,
             	tittel TEXT,
             	tema TEXT,
             	registrert TEXT,
             	harTilgangTilArkivvariant INTEGER,
-            	valgt INTEGER
-            )
-            "
-        db.execute "CREATE TABLE Vedlegg
-            (
-            	dokumentInfoId TEXT PRIMARY KEY,
-            	tittel TEXT,
-            	harTilgangTilArkivvariant INTEGER,
-            	valgt INTEGER
+              PRIMARY KEY (journalpostId, dokumentInfoId)
             )
             "
   rescue SQLite3::Exception => e
@@ -39,26 +28,11 @@ def init()
   end
 end
 
-def insert_dokument(journalpostId, dokumentInfoId, tittel, tema, registrert, harTilgangTilArkivvariant, valgt)
+def insert_dokument(journalpostId, dokumentInfoId, tittel, tema, registrert, harTilgangTilArkivvariant)
   begin
 	  db = SQLite3::Database.open ARGV[0]
-      db.execute("INSERT INTO Dokumenter (journalpostId, dokumentInfoId, tittel, tema, registrert, harTilgangTilArkivvariant, valgt) VALUES (?, ?, ?, ?, ?, ?, ?)",
-                                        [journalpostId, dokumentInfoId, tittel, tema, registrert.to_s, harTilgangTilArkivvariant, valgt])
-
-  rescue SQLite3::Exception => e
-    puts "Exception occurred"
-    puts e
-    exit
-  ensure
-    db.close if db
-  end
-end
-
-def insert_vedlegg(dokumentInfoId, tittel, harTilgangTilArkivvariant, valgt)
-  begin
-	  db = SQLite3::Database.open ARGV[0]
-      db.execute("INSERT INTO Vedlegg (dokumentInfoId, tittel, harTilgangTilArkivvariant, valgt) VALUES (?, ?, ?, ?)",
-                                        [dokumentInfoId, tittel, harTilgangTilArkivvariant, valgt])
+      db.execute("INSERT INTO Dokumenter (journalpostId, dokumentInfoId, tittel, tema, registrert, harTilgangTilArkivvariant) VALUES (?, ?, ?, ?, ?, ?)",
+                                        [journalpostId, dokumentInfoId, tittel, tema, registrert.to_s, harTilgangTilArkivvariant])
 
   rescue SQLite3::Exception => e
     puts "Exception occurred"
@@ -83,30 +57,14 @@ def tilfeldigTema()
   return "SYK"
 end
 
-def tilfeldigTrueFalse()
-  return rand(2) == 1 ? 1 : 0
-end
-
 def lagDokument()
-  journalpostId = Faker::Number.number(digits: 9)
+  journalpostId = Faker::Number.number(digits: 2)
   dokumentInfoId = Faker::Number.number(digits: 9)
   tittel = Faker::Book.title()
   tema = tilfeldigTema()
   registrert = Faker::Date.backward(days: 365)
-  harTilgangTilArkivvariant = tilfeldigTrueFalse()
-  valgt = tilfeldigTrueFalse()
-  insert_dokument(journalpostId, dokumentInfoId, tittel, tema, registrert, harTilgangTilArkivvariant, valgt)
-end
-
-def lagVedlegg()
-  journalpostId = Faker::Number.number(digits: 9)
-  dokumentInfoId = Faker::Number.number(digits: 9)
-  tittel = Faker::Marketing.buzzwords()
-  tema = tilfeldigTema()
-  registrert = Faker::Date.backward(days: 365)
-  harTilgangTilArkivvariant = tilfeldigTrueFalse()
-  valgt = tilfeldigTrueFalse()
-  insert_vedlegg(dokumentInfoId, tittel,harTilgangTilArkivvariant, valgt)
+  harTilgangTilArkivvariant = Faker::Boolean.boolean(true_ratio: 0.8) ? 1 : 0
+  insert_dokument(journalpostId, dokumentInfoId, tittel, tema, registrert, harTilgangTilArkivvariant)
 end
 
 init()
@@ -114,16 +72,12 @@ init()
 i=0
 
 # trenger disse for test
-insert_dokument("test_journalpostId", "test_dokumentInfoId", "test_tittel", "test_tema", "2020-12-31", 1,1)
-insert_vedlegg("test_dokumentInfoId_2", "test_vedlegg_tittel", 1, 1)
+insert_dokument("test_journalpostId", "test_dokumentInfoId", "test_tittel", "test_tema", "2020-12-31", 1)
 
 loop do
   lagDokument()
-  lagVedlegg()
   i += 1;
   if i == 500
     break
   end
 end
-
-

--- a/api-mock-server/src/dokumenter/dokumenter.ts
+++ b/api-mock-server/src/dokumenter/dokumenter.ts
@@ -1,0 +1,44 @@
+import sqlite3 from "sqlite3";
+import { IDbDokument, IDokument, IDokumentVedlegg } from "./types";
+
+export async function hentDokumenter(): Promise<IDokument[]> {
+  const db = new sqlite3.Database("./oppgaver.db");
+  const query =
+    `SELECT journalpostId, dokumentInfoId, tittel, tema, registrert, harTilgangTilArkivvariant FROM Dokumenter ORDER BY registrert DESC`.trim();
+  console.debug("hentDokumenter query", query);
+
+  const dokumenter = await new Promise<IDbDokument[]>((resolve, reject) => {
+    db.all(query, (err, rows) => {
+      if (err) {
+        reject(err);
+      }
+      resolve(rows);
+    });
+    db.close((err) => {
+      if (err !== null) {
+        console.error(err.message);
+      }
+      console.log("Close the database connection.");
+    });
+  });
+
+  return dokumenter
+    .map<IDokument>((d) => ({
+      ...d,
+      vedlegg: [],
+      harTilgangTilArkivvariant: d.harTilgangTilArkivvariant === 1,
+    }))
+    .reduce<IDokument[]>((nested, current) => {
+      const dokument = nested.find(({ journalpostId }) => journalpostId === current.journalpostId);
+      if (dokument === undefined) {
+        return [...nested, current];
+      }
+      const vedlegg: IDokumentVedlegg = {
+        dokumentInfoId: current.dokumentInfoId,
+        harTilgangTilArkivvariant: current.harTilgangTilArkivvariant,
+        tittel: current.tittel,
+      };
+      dokument.vedlegg.push(vedlegg);
+      return nested;
+    }, []);
+}

--- a/api-mock-server/src/dokumenter/types.ts
+++ b/api-mock-server/src/dokumenter/types.ts
@@ -1,0 +1,24 @@
+export interface IDbDokument {
+  journalpostId: string;
+  dokumentInfoId: string;
+  tittel: string | null;
+  tema: string | null;
+  registrert: string; // LocalDate
+  harTilgangTilArkivvariant: number;
+}
+
+export interface IDokument {
+  journalpostId: string;
+  dokumentInfoId: string;
+  tittel: string | null;
+  tema: string | null;
+  registrert: string; // LocalDate
+  harTilgangTilArkivvariant: boolean;
+  vedlegg: IDokumentVedlegg[];
+}
+
+export interface IDokumentVedlegg {
+  dokumentInfoId: string;
+  tittel: string | null;
+  harTilgangTilArkivvariant: boolean;
+}

--- a/api-mock-server/src/klagebehandling/klagebehandling.ts
+++ b/api-mock-server/src/klagebehandling/klagebehandling.ts
@@ -1,0 +1,50 @@
+import { klagebehandlingDetaljerView } from "./klagebehandlingDetaljerView";
+import { Editerbare, IKlagebehandling } from "./types";
+
+const klager: Map<string, IKlagebehandling> = new Map();
+
+export const getKlage = (id: string): IKlagebehandling => {
+  const klage = klager.get(id);
+  if (klage !== undefined) {
+    return klage;
+  }
+  const newKlage = { ...klagebehandlingDetaljerView, id };
+  klager.set(id, newKlage);
+  return newKlage;
+};
+
+export const saveKlage = (oppdatering: Editerbare) => {
+  if (
+    typeof oppdatering.klagebehandlingId !== "string" ||
+    oppdatering.klagebehandlingId.length === 0
+  ) {
+    throw new Error("KlagebehandlingID mangler");
+  }
+  const klage = getKlage(oppdatering.klagebehandlingId);
+  if (klage.klagebehandlingVersjon !== oppdatering.klagebehandlingVersjon) {
+    throw new Error("Feil klageversjon");
+  }
+
+  const oppdatert: IKlagebehandling = {
+    ...klage,
+    klagebehandlingVersjon: klage.klagebehandlingVersjon + 1,
+    modified: new Date().toISOString(),
+    internVurdering: oppdatering.internVurdering,
+    tilknyttedeDokumenter: oppdatering.tilknyttedeDokumenter,
+    vedtak: [
+      {
+        ...klage.vedtak[0],
+        grunn: oppdatering.grunn,
+        hjemler: oppdatering.hjemler,
+        utfall: oppdatering.utfall,
+      },
+    ],
+  };
+
+  klager.set(oppdatering.klagebehandlingId, oppdatert);
+
+  return {
+    klagebehandlingVersjon: oppdatert.klagebehandlingVersjon,
+    modified: oppdatert.modified,
+  };
+};

--- a/api-mock-server/src/klagebehandling/klagebehandlingDetaljerView.ts
+++ b/api-mock-server/src/klagebehandling/klagebehandlingDetaljerView.ts
@@ -1,4 +1,6 @@
-export const klagebehandlingDetaljerView = {
+import { IKlagebehandling } from "./types";
+
+export const klagebehandlingDetaljerView: IKlagebehandling = {
   id: "a6257f0d-c79c-4844-bfc6-a45ae6d6976f",
   klageInnsendtdato: "2020-08-11",
   fraNAVEnhet: "0104",
@@ -20,18 +22,17 @@ export const klagebehandlingDetaljerView = {
     mellomnavn: "Camilla",
     etternavn: "Petersen",
   },
-  foedselsnummer: "17457337760",
-  virksomhetsnummer: null,
   tema: "43",
   type: "1",
   mottatt: "2021-04-26",
-  startet: "2021-04-27",
-  avsluttet: null,
   avsluttetAvSaksbehandler: null,
   frist: null,
   tildeltSaksbehandlerident: "Z994488",
   medunderskriverident: "",
-  erMedunderskriver: null,
+  datoSendtMedunderskriver: null,
+  klagerKjoenn: null,
+  mottattKlageinstans: null,
+  sakenGjelderVirksomhetsnavn: null,
   hjemler: ["1000.008.004"],
   modified: "2021-04-27T08:56:30.679251",
   created: "2021-04-26T18:25:08.859951",
@@ -50,9 +51,11 @@ export const klagebehandlingDetaljerView = {
       hjemler: [],
       brevMottakere: [],
       ferdigstilt: null,
+      opplastet: null,
       file: null,
     },
   ],
   kommentarFraFoersteinstans: null,
   tilknyttedeDokumenter: [],
+  tildelt: null,
 };

--- a/api-mock-server/src/klagebehandling/types.ts
+++ b/api-mock-server/src/klagebehandling/types.ts
@@ -1,13 +1,3 @@
-import { IKodeverkVerdi } from "../kodeverk";
-import { IKlagebehandlingOppdatering } from "./types";
-
-export interface IKlagebehandlingState {
-  opptatt: boolean;
-  lagretVersjon: IKlagebehandlingOppdatering | null;
-  error: string | null;
-  klagebehandling: IKlagebehandling | null;
-}
-
 export interface IKlagebehandling {
   avsluttetAvSaksbehandler: string | null;
   created: string; // LocalDateTime
@@ -91,31 +81,12 @@ export interface IVedlegg {
   opplastet: string | null; // LocalDateTime
 }
 
-export interface GrunnerPerUtfall {
-  utfallId: string;
-  grunner: IKodeverkVerdi[];
-}
-
-export interface IKlagePayload {
-  id: string;
-}
-
-export interface IDokumenter {
-  saksbehandlerHarTilgang: boolean;
-}
-
-export interface IDokumentPayload {
-  id: string;
-  journalpostId: string;
-  dokumentInfoId: string;
-  erVedlegg: boolean;
-}
-
-export interface IDokumentParams {
-  id: string;
-  idx: number;
-  handling: string;
-  antall: number;
-  ref: string | null;
-  historyNavigate: boolean;
+export interface Editerbare {
+  klagebehandlingId: string;
+  klagebehandlingVersjon: number;
+  internVurdering: string;
+  grunn: string | null;
+  utfall: string | null;
+  hjemler: string[];
+  tilknyttedeDokumenter: TilknyttetDokument[];
 }

--- a/api-mock-server/src/oppgaver.spec.ts
+++ b/api-mock-server/src/oppgaver.spec.ts
@@ -1,4 +1,4 @@
-import { filtrerOppgaver, toggleDokument, toggleVedlegg } from "./oppgaver";
+import { filtrerOppgaver } from "./oppgaver";
 
 type Oppgaver = {
   antallTreffTotalt: number;
@@ -104,8 +104,7 @@ describe("tester oppgavehenting", () => {
     let i = 0;
     while (++i < resultat.klagebehandlinger.length)
       expect(
-        resultat.klagebehandlinger[i].tema == "30" ||
-          resultat.klagebehandlinger[i].tema == "43"
+        resultat.klagebehandlinger[i].tema == "30" || resultat.klagebehandlinger[i].tema == "43"
       ).toBe(true);
   });
 
@@ -151,44 +150,5 @@ describe("tester oppgavehenting", () => {
     };
     let result = await filtrerOppgaver(query);
     expect(result.klagebehandlinger.length).toBeGreaterThan(1);
-  });
-  it("toggle dokument", async () => {
-    let behandlingId = "123";
-    let journalpostId = "test_journalpostId";
-    let dokumentInfoId = "test_dokumentInfoId";
-
-    let result = await toggleDokument({
-      id: behandlingId,
-      journalpostId,
-      dokumentInfoId,
-    });
-    expect(result).toBe("1 endret til 0");
-
-    result = await toggleDokument({
-      id: behandlingId,
-      journalpostId,
-      dokumentInfoId,
-    });
-    expect(result).toBe("0 endret til 1");
-  });
-
-  it("toggle vedlegg", async () => {
-    let behandlingId = "123";
-    let journalpostId = "test_journalpostId";
-    let dokumentInfoId = "test_dokumentInfoId_2";
-
-    let result = await toggleVedlegg({
-      id: behandlingId,
-      journalpostId,
-      dokumentInfoId,
-    });
-    expect(result).toBe("1 endret til 0");
-
-    result = await toggleVedlegg({
-      id: behandlingId,
-      journalpostId,
-      dokumentInfoId,
-    });
-    expect(result).toBe("0 endret til 1");
   });
 });

--- a/api-mock-server/src/server.ts
+++ b/api-mock-server/src/server.ts
@@ -92,6 +92,8 @@ app.get("/klagebehandlinger/:id/dokumenter", async (req, res) => {
     })
   );
 
+  await sleep(2000);
+
   res.json({
     dokumenter,
     pageReference: null,

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30681,9 +30681,7 @@
       "version": "1.0.19",
       "resolved": "https://registry.npmjs.org/nav-frontend-js-utils/-/nav-frontend-js-utils-1.0.19.tgz",
       "integrity": "sha512-Z+ZGNcghkbx0VT0AN3H5ftCWWRMpXGcMI2JnMQJGzS8CkbjIEU8nkxsU63tyzq/n1BK69z1xT/1Vju6DRROidQ==",
-      "requires": {
-        "lodash.throttle": "^4.1.1"
-      }
+      "requires": {}
     },
     "nav-frontend-knapper": {
       "version": "2.1.4",

--- a/frontend/src/komponenter/Header/Header.tsx
+++ b/frontend/src/komponenter/Header/Header.tsx
@@ -88,6 +88,7 @@ export const Bruker = ({ navn }: Brukerinfo) => {
                     <EnhetKnapp
                       onClick={() => settEnhet(enhet.id)}
                       disabled={person.valgtEnhet.id === enhet.id}
+                      active={person.valgtEnhet.id === enhet.id}
                     >
                       {enhet.id} {enhet.navn}
                     </EnhetKnapp>
@@ -146,7 +147,7 @@ const EnhetListe = styled.ul`
   margin: 0;
 `;
 
-const EnhetKnapp = styled.button`
+const EnhetKnapp = styled.button<{ active: boolean }>`
   display: block;
   width: 100%;
   background-color: transparent;
@@ -158,9 +159,13 @@ const EnhetKnapp = styled.button`
   border: none;
   cursor: pointer;
   text-align: left;
+  font-weight: ${({ active }) => (active ? "bold" : "normal")};
 
   :hover,
   :active {
     background-color: #e7e9e9;
+  }
+  :disabled {
+    cursor: default;
   }
 `;

--- a/frontend/src/komponenter/Header/Header.tsx
+++ b/frontend/src/komponenter/Header/Header.tsx
@@ -2,15 +2,15 @@ import React, { ReactNode, useEffect, useRef, useState } from "react";
 import { useSelector } from "react-redux";
 import { NavLink, useHistory } from "react-router-dom";
 import classNames from "classnames";
+import styled from "styled-components";
 import IkonSystem from "./icons/IkonSystem";
-import "./Header.less";
 import { velgMeg } from "../../tilstand/moduler/meg.velgere";
 import { settEnhetHandling } from "../../tilstand/moduler/meg";
 import { useOnInteractOutside } from "../Tabell/FiltrerbarHeader";
-import styled from "styled-components";
 import { velgFeatureToggles } from "../../tilstand/moduler/unleash.velgere";
 import { useAppDispatch } from "../../tilstand/konfigurerTilstand";
 import isDevLocation from "../../utility/isDevLocation";
+import "./Header.less";
 
 const BrukerBoks = styled.div`
   z-index: 2;
@@ -30,16 +30,14 @@ export interface HeaderProps {
   children?: ReactNode | ReactNode[];
 }
 
-export const Bruker = ({ navn, ident, enhet, rolle }: Brukerinfo) => {
+export const Bruker = ({ navn }: Brukerinfo) => {
   const [aapen, setAapen] = useState(false);
-  const [satte_valgtEnhet, settValgtEnhet] = useState(0);
   const [harAdminTilgang, settHarAdminTilgang] = useState(false);
   const person = useSelector(velgMeg);
   const dispatch = useAppDispatch();
   const { enheter, valgtEnhet } = person;
   const ref = useRef<HTMLDivElement>(null);
   const featureToggles = useSelector(velgFeatureToggles);
-  const history = useHistory();
 
   useEffect(() => {
     const adminEnabled = featureToggles.features.find((f) => f?.navn === "klage.admin");
@@ -55,12 +53,7 @@ export const Bruker = ({ navn, ident, enhet, rolle }: Brukerinfo) => {
     active: aapen,
   });
 
-  const settEnhet = (
-    event: React.MouseEvent<HTMLElement | HTMLButtonElement>,
-    index: number,
-    id: string
-  ) => {
-    settValgtEnhet(index);
+  const settEnhet = (id: string) => {
     dispatch(settEnhetHandling({ enhetId: id, navIdent: person.graphData.id }));
     setAapen(false);
   };
@@ -87,26 +80,22 @@ export const Bruker = ({ navn, ident, enhet, rolle }: Brukerinfo) => {
       </button>
       <div className={classNames(aapen ? "velg-enhet maksimert" : "minimert")} ref={ref}>
         <div className={"enheter"}>
-          {(() => {
-            if (isDevLocation() || !harAdminTilgang) {
-              return enheter.map((enhet, index) => {
-                return (
-                  <div
-                    className={classNames({
-                      enhet: true,
-                      active: person.valgtEnhet.id === enhet.id,
-                    })}
-                    key={enhet.id}
-                  >
-                    <NavLink to={"#"} onClick={(e) => settEnhet(e, index, enhet.id)}>
+          <EnhetListe>
+            {(() => {
+              if (isDevLocation() || !harAdminTilgang) {
+                return enheter.map((enhet) => (
+                  <li key={enhet.id}>
+                    <EnhetKnapp
+                      onClick={() => settEnhet(enhet.id)}
+                      disabled={person.valgtEnhet.id === enhet.id}
+                    >
                       {enhet.id} {enhet.navn}
-                    </NavLink>
-                  </div>
-                );
-              });
-            }
-          })()}
-          <hr />
+                    </EnhetKnapp>
+                  </li>
+                ));
+              }
+            })()}
+          </EnhetListe>
           {harAdminTilgang && (
             <NavLink to={"/admin"} className={classNames({ enhet: true, navlink: true })}>
               Admin
@@ -149,3 +138,29 @@ export const Header = ({ tittel, backLink, children, brukerinfo }: HeaderProps) 
     </header>
   );
 };
+
+const EnhetListe = styled.ul`
+  list-style: none;
+  border-bottom: 1px solid grey;
+  padding: 0;
+  margin: 0;
+`;
+
+const EnhetKnapp = styled.button`
+  display: block;
+  width: 100%;
+  background-color: transparent;
+  padding-left: 2em;
+  padding-top: 0.5em;
+  padding-bottom: 0.5em;
+  color: black;
+  font-size: 1em;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+
+  :hover,
+  :active {
+    background-color: #e7e9e9;
+  }
+`;

--- a/frontend/src/komponenter/Klagebehandling/Dokumenter/AlleDokumenter.tsx
+++ b/frontend/src/komponenter/Klagebehandling/Dokumenter/AlleDokumenter.tsx
@@ -7,12 +7,8 @@ import {
   IDokumentListe,
   IDokumentVedlegg,
 } from "../../../tilstand/moduler/dokumenter/stateTypes";
-import { ITilknyttetDokument, ITilknyttetVedlegg } from "./typer";
-import {
-  frakobleDokument,
-  hentDokumenter,
-  tilknyttDokument,
-} from "../../../tilstand/moduler/dokumenter/actions";
+import { IShownDokument, ITilknyttetDokument, ITilknyttetVedlegg } from "./typer";
+import { hentDokumenter } from "../../../tilstand/moduler/dokumenter/actions";
 import { useKanEndre } from "../utils/hooks";
 import { IKlagebehandling } from "../../../tilstand/moduler/klagebehandling/stateTypes";
 import { dokumentMatcher } from "./helpers";
@@ -33,178 +29,233 @@ import {
   VedleggTittel,
   StyledLastFlereKnapp,
 } from "./styled-components/fullvisning";
+import {
+  FRAKOBLE_DOKUMENT,
+  TILKNYTT_DOKUMENT,
+} from "../../../tilstand/moduler/klagebehandling/state";
+import { TilknyttetDokument } from "../../../tilstand/moduler/klagebehandling/types";
 
 interface AlleDokumenterProps {
   dokumenter: IDokumentListe;
   klagebehandling: IKlagebehandling;
   skjult: boolean;
-  visDokument: (dokument: IDokument) => void;
+  visDokument: (dokument: IShownDokument) => void;
 }
 
-export const AlleDokumenter = ({
-  dokumenter,
-  klagebehandling,
-  skjult,
-  visDokument,
-}: AlleDokumenterProps) => {
-  const dispatch = useAppDispatch();
-  const kanEndre = useKanEndre();
+export const AlleDokumenter = React.memo(
+  ({ dokumenter, klagebehandling, skjult, visDokument }: AlleDokumenterProps) => {
+    const kanEndre = useKanEndre();
+    const alleDokumenter = useMemo<ITilknyttetDokument[]>(
+      () =>
+        dokumenter.dokumenter.map((dokument) => ({
+          dokument,
+          tilknyttet: klagebehandling.tilknyttedeDokumenter.some((t) =>
+            dokumentMatcher(t, dokument)
+          ),
+        })),
+      [dokumenter.dokumenter, klagebehandling.tilknyttedeDokumenter]
+    );
 
-  const alleDokumenter = useMemo<ITilknyttetDokument[]>(
-    () =>
-      dokumenter.dokumenter.map((dokument) => ({
-        dokument,
-        tilknyttet: klagebehandling.tilknyttedeDokumenter.some((t) => dokumentMatcher(t, dokument)),
-      })),
-    [dokumenter.dokumenter, dokumenter.loading, klagebehandling.tilknyttedeDokumenter]
-  );
+    if (skjult) {
+      return null;
+    }
 
-  const onCheck = useCallback(
-    (checked: boolean, dokument: IDokument) => {
-      dispatch(checked ? tilknyttDokument(dokument) : frakobleDokument(dokument));
-    },
-    [dispatch]
-  );
+    if (dokumenter.loading && alleDokumenter.length === 0) {
+      return <NavFrontendSpinner />;
+    }
 
-  if (skjult) {
-    return null;
-  }
-
-  if (dokumenter.loading && alleDokumenter.length === 0) {
-    return <NavFrontendSpinner />;
-  }
-
-  return (
-    <DokumenterFullvisning>
-      <List data-testid={"dokumenter"}>
-        {alleDokumenter.map(({ dokument, tilknyttet }) => (
-          <ListItem key={dokument.journalpostId + dokument.dokumentInfoId}>
-            <DokumentRad>
-              <DokumentTittel onClick={() => visDokument(dokument)}>
-                {dokument.tittel}
-              </DokumentTittel>
-              <DokumentTema
-                onClick={() => visDokument(dokument)}
-                className={`etikett etikett--mw etikett--info etikett--${dokument
-                  .tema!.split(" ")[0]
-                  .toLowerCase()}`}
-              >
-                <TemaText>{dokument.tema}</TemaText>
-              </DokumentTema>
-              <DokumentDato onClick={() => visDokument(dokument)} className={"liten"}>
-                {formattedDate(dokument.registrert)}
-              </DokumentDato>
-
-              <DokumentSjekkboks>
-                <RightAlign>
-                  <DokumentCheckbox
-                    label={""}
-                    disabled={!dokument.harTilgangTilArkivvariant || !kanEndre}
-                    defaultChecked={tilknyttet}
-                    onChange={(e) => onCheck(e.currentTarget.checked, dokument)}
-                  />
-                </RightAlign>
-              </DokumentSjekkboks>
-              <VedleggListe
+    return (
+      <DokumenterFullvisning>
+        <List data-testid={"dokumenter"}>
+          {alleDokumenter.map(({ dokument, tilknyttet }) => (
+            <ListItem key={`dokument_${dokument.journalpostId}_${dokument.dokumentInfoId}`}>
+              <Dokument
+                kanEndre={kanEndre}
                 dokument={dokument}
-                klagebehandling={klagebehandling}
+                tilknyttet={tilknyttet}
                 visDokument={visDokument}
-                onCheck={onCheck}
+                klagebehandling={klagebehandling}
               />
-            </DokumentRad>
-          </ListItem>
-        ))}
-      </List>
-      <LastFlere
-        dokumenter={dokumenter}
-        klagebehandlingId={klagebehandling.id}
-        loading={dokumenter.loading}
-      />
-    </DokumenterFullvisning>
-  );
-};
+            </ListItem>
+          ))}
+        </List>
+        <LastFlere
+          dokumenter={dokumenter}
+          klagebehandlingId={klagebehandling.id}
+          loading={dokumenter.loading}
+        />
+      </DokumenterFullvisning>
+    );
+  },
+  (previous, next) =>
+    previous.skjult === next.skjult &&
+    previous.dokumenter.loading === next.dokumenter.loading &&
+    previous.dokumenter.dokumenter === next.dokumenter.dokumenter &&
+    previous.klagebehandling.id === next.klagebehandling.id &&
+    previous.visDokument === next.visDokument
+);
+
+interface DokumentProps extends ITilknyttetDokument {
+  klagebehandling: IKlagebehandling;
+  kanEndre: boolean;
+  visDokument: (dokument: IShownDokument) => void;
+}
+
+const Dokument = React.memo<DokumentProps>(
+  ({ dokument, tilknyttet, kanEndre, visDokument, klagebehandling }) => {
+    const dispatch = useAppDispatch();
+
+    const onShowDokument = ({
+      journalpostId,
+      dokumentInfoId,
+      tittel,
+      harTilgangTilArkivvariant,
+    }: IDokument) =>
+      visDokument({ journalpostId, dokumentInfoId, tittel, harTilgangTilArkivvariant });
+
+    const onCheck = (checked: boolean) => {
+      const d: TilknyttetDokument = {
+        journalpostId: dokument.journalpostId,
+        dokumentInfoId: dokument.dokumentInfoId,
+      };
+      dispatch(checked ? TILKNYTT_DOKUMENT(d) : FRAKOBLE_DOKUMENT(d));
+    };
+
+    return (
+      <DokumentRad>
+        <DokumentTittel onClick={() => onShowDokument(dokument)}>{dokument.tittel}</DokumentTittel>
+        <DokumentTema
+          onClick={() => onShowDokument(dokument)}
+          className={`etikett etikett--mw etikett--info etikett--${dokument
+            .tema!.split(" ")[0]
+            .toLowerCase()}`}
+        >
+          <TemaText>{dokument.tema}</TemaText>
+        </DokumentTema>
+        <DokumentDato onClick={() => onShowDokument(dokument)} className={"liten"}>
+          {formattedDate(dokument.registrert)}
+        </DokumentDato>
+
+        <DokumentSjekkboks>
+          <RightAlign>
+            <DokumentCheckbox
+              label={""}
+              disabled={!dokument.harTilgangTilArkivvariant || !kanEndre}
+              defaultChecked={tilknyttet}
+              onChange={(e) => onCheck(e.currentTarget.checked)}
+            />
+          </RightAlign>
+        </DokumentSjekkboks>
+        <VedleggListe
+          dokument={dokument}
+          klagebehandling={klagebehandling}
+          kanEndre={kanEndre}
+          visDokument={visDokument}
+        />
+      </DokumentRad>
+    );
+  },
+  (previous, next) =>
+    previous.tilknyttet === next.tilknyttet &&
+    previous.kanEndre === next.kanEndre &&
+    dokumentMatcher(previous.dokument, next.dokument)
+);
 
 interface VedleggListeProps {
   klagebehandling: IKlagebehandling;
   dokument: IDokument;
-  visDokument: (dokument: IDokument) => void;
-  onCheck: (checked: boolean, dokument: IDokument) => void;
+  kanEndre: boolean;
+  visDokument: (dokument: IShownDokument) => void;
 }
 
-const VedleggListe = ({ klagebehandling, dokument, visDokument, onCheck }: VedleggListeProps) => {
-  const vedleggListe = useMemo<ITilknyttetVedlegg[]>(
-    () =>
-      dokument.vedlegg.map((vedlegg) => ({
-        vedlegg,
-        tilknyttet: klagebehandling.tilknyttedeDokumenter.some(
-          ({ dokumentInfoId, journalpostId }) =>
-            vedlegg.dokumentInfoId === dokumentInfoId && dokument.journalpostId === journalpostId
-        ),
-      })),
-    [dokument.vedlegg, dokument.journalpostId, klagebehandling.tilknyttedeDokumenter]
-  );
+const VedleggListe = React.memo(
+  ({ klagebehandling, dokument, kanEndre, visDokument }: VedleggListeProps) => {
+    const vedleggListe = useMemo<ITilknyttetVedlegg[]>(
+      () =>
+        dokument.vedlegg.map((vedlegg) => ({
+          vedlegg,
+          tilknyttet: klagebehandling.tilknyttedeDokumenter.some(
+            ({ dokumentInfoId, journalpostId }) =>
+              vedlegg.dokumentInfoId === dokumentInfoId && dokument.journalpostId === journalpostId
+          ),
+        })),
+      [dokument.vedlegg, dokument.journalpostId, klagebehandling.tilknyttedeDokumenter]
+    );
 
-  if (dokument.vedlegg.length === 0) {
-    return null;
-  }
+    if (dokument.vedlegg.length === 0) {
+      return null;
+    }
 
-  return (
-    <VedleggBeholder data-testid={"vedlegg"}>
-      {vedleggListe.map(({ vedlegg, tilknyttet }) => (
-        <VedleggKomponent
-          key={`vedlegg_${dokument.journalpostId}_${vedlegg.dokumentInfoId}`}
-          vedlegg={vedlegg}
-          dokument={dokument}
-          tilknyttet={tilknyttet}
-          visDokument={visDokument}
-          onCheck={onCheck}
-        />
-      ))}
-    </VedleggBeholder>
-  );
-};
-
+    return (
+      <VedleggBeholder data-testid={"vedlegg"}>
+        {vedleggListe.map(({ vedlegg, tilknyttet }) => (
+          <VedleggKomponent
+            key={`vedlegg_${dokument.journalpostId}_${vedlegg.dokumentInfoId}`}
+            kanEndre={kanEndre}
+            vedlegg={vedlegg}
+            dokument={dokument}
+            tilknyttet={tilknyttet}
+            visDokument={visDokument}
+          />
+        ))}
+      </VedleggBeholder>
+    );
+  },
+  (previous, next) =>
+    previous.kanEndre === next.kanEndre &&
+    dokumentMatcher(previous.dokument, next.dokument) &&
+    previous.klagebehandling.tilknyttedeDokumenter === next.klagebehandling.tilknyttedeDokumenter
+);
 interface VedleggKomponentProps {
   dokument: IDokument;
   vedlegg: IDokumentVedlegg;
   tilknyttet: boolean;
-  visDokument: (dokument: IDokument) => void;
-  onCheck: (checked: boolean, dokument: IDokument) => void;
+  kanEndre: boolean;
+  visDokument: (dokument: IShownDokument) => void;
 }
 
-const VedleggKomponent = ({
-  vedlegg,
-  dokument,
-  tilknyttet,
-  visDokument,
-  onCheck,
-}: VedleggKomponentProps) => {
-  const kanEndre = useKanEndre();
-  const vedleggDokument = useMemo(
-    () => ({
-      ...dokument,
-      ...vedlegg,
-    }),
-    [dokument, vedlegg]
-  );
+const VedleggKomponent = React.memo<VedleggKomponentProps>(
+  ({ vedlegg, dokument, tilknyttet, kanEndre, visDokument }) => {
+    const dispatch = useAppDispatch();
 
-  return (
-    <VedleggRad key={dokument.journalpostId + vedlegg.dokumentInfoId}>
-      <VedleggTittel onClick={() => visDokument(vedleggDokument)}>{vedlegg.tittel}</VedleggTittel>
+    const onCheck = (checked: boolean) => {
+      const d: TilknyttetDokument = {
+        journalpostId: dokument.journalpostId,
+        dokumentInfoId: vedlegg.dokumentInfoId,
+      };
+      dispatch(checked ? TILKNYTT_DOKUMENT(d) : FRAKOBLE_DOKUMENT(d));
+    };
 
-      <DokumentSjekkboks className={"dokument-sjekkboks"}>
-        <RightAlign>
-          <DokumentCheckbox
-            label={""}
-            disabled={!dokument.harTilgangTilArkivvariant || !kanEndre}
-            defaultChecked={tilknyttet}
-            onChange={(e) => onCheck(e.currentTarget.checked, vedleggDokument)}
-          />
-        </RightAlign>
-      </DokumentSjekkboks>
-    </VedleggRad>
-  );
-};
+    const onVisDokument = () =>
+      visDokument({
+        journalpostId: dokument.journalpostId,
+        dokumentInfoId: vedlegg.dokumentInfoId,
+        tittel: vedlegg.tittel,
+        harTilgangTilArkivvariant: vedlegg.harTilgangTilArkivvariant,
+      });
+
+    return (
+      <VedleggRad key={dokument.journalpostId + vedlegg.dokumentInfoId}>
+        <VedleggTittel onClick={onVisDokument}>{vedlegg.tittel}</VedleggTittel>
+        <DokumentSjekkboks className={"dokument-sjekkboks"}>
+          <RightAlign>
+            <DokumentCheckbox
+              label={""}
+              disabled={!vedlegg.harTilgangTilArkivvariant || !kanEndre}
+              defaultChecked={tilknyttet}
+              onChange={(e) => onCheck(e.currentTarget.checked)}
+            />
+          </RightAlign>
+        </DokumentSjekkboks>
+      </VedleggRad>
+    );
+  },
+  (previous, next) =>
+    previous.tilknyttet === next.tilknyttet &&
+    previous.kanEndre === next.kanEndre &&
+    previous.vedlegg.dokumentInfoId === next.vedlegg.dokumentInfoId &&
+    dokumentMatcher(previous.dokument, next.dokument)
+);
 
 interface LoadMoreProps {
   dokumenter: IDokumentListe;
@@ -218,11 +269,9 @@ const LastFlere = ({ dokumenter, klagebehandlingId, loading }: LoadMoreProps) =>
     () => dispatch(hentDokumenter({ klagebehandlingId, pageReference: dokumenter.pageReference })),
     [dokumenter.pageReference, klagebehandlingId]
   );
-  const remaining = useMemo(
-    () => dokumenter.totaltAntall - dokumenter.dokumenter.length,
-    [dokumenter.dokumenter.length, dokumenter.totaltAntall]
-  );
-  const hasMore = useMemo(() => remaining !== 0, [remaining]);
+
+  const remaining = dokumenter.totaltAntall - dokumenter.dokumenter.length;
+  const hasMore = remaining !== 0;
 
   if (!hasMore) {
     return null;

--- a/frontend/src/komponenter/Klagebehandling/Dokumenter/Dokumenter.tsx
+++ b/frontend/src/komponenter/Klagebehandling/Dokumenter/Dokumenter.tsx
@@ -1,10 +1,6 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useAppDispatch, useAppSelector } from "../../../tilstand/konfigurerTilstand";
-import {
-  velgAlleDokumenter,
-  velgTilknyttedeDokumenter,
-} from "../../../tilstand/moduler/dokumenter/selectors";
-import { IDokument } from "../../../tilstand/moduler/dokumenter/stateTypes";
+import { velgAlleDokumenter } from "../../../tilstand/moduler/dokumenter/selectors";
 import { ShowDokument } from "./ShowDokument";
 import { DokumenterBeholder } from "./styled-components/container";
 import { TilknyttedeDokumenter } from "./TilknyttedeDokumenter";
@@ -16,6 +12,7 @@ import {
 import { NULLSTILL_DOKUMENTER } from "../../../tilstand/moduler/dokumenter/state";
 import { Header } from "./Header";
 import { IKlagebehandling } from "../../../tilstand/moduler/klagebehandling/stateTypes";
+import { IShownDokument } from "./typer";
 
 export interface DokumenterProps {
   skjult: boolean;
@@ -32,8 +29,9 @@ export const Dokumenter = ({
 }: DokumenterProps) => {
   const dispatch = useAppDispatch();
   const alleDokumenter = useAppSelector(velgAlleDokumenter);
-  const tilknyttedeDokumenter = useAppSelector(velgTilknyttedeDokumenter);
-  const [dokument, settDokument] = useState<IDokument | null>(null);
+  const [dokument, settDokument] = useState<IShownDokument | null>(null);
+
+  const antallTilknyttede = klagebehandling.tilknyttedeDokumenter.length;
 
   useEffect(() => {
     dispatch(hentDokumenter({ klagebehandlingId: klagebehandling.id, pageReference: null }));
@@ -43,15 +41,6 @@ export const Dokumenter = ({
     };
   }, [klagebehandling.id, dispatch]);
 
-  const visDokument = useCallback(
-    (dokument: IDokument) => {
-      if (dokument.harTilgangTilArkivvariant) {
-        settDokument(dokument);
-      }
-    },
-    [settDokument]
-  );
-
   if (skjult) {
     return null;
   }
@@ -59,17 +48,20 @@ export const Dokumenter = ({
   return (
     <>
       <DokumenterBeholder fullvisning={fullvisning}>
-        <Header settFullvisning={settFullvisning} fullvisning={fullvisning} />
+        <Header
+          settFullvisning={settFullvisning}
+          fullvisning={fullvisning}
+          antall={antallTilknyttede}
+        />
         <TilknyttedeDokumenter
           skjult={fullvisning}
-          dokumenter={tilknyttedeDokumenter}
-          visDokument={visDokument}
-          klagebehandling={klagebehandling}
+          visDokument={settDokument}
+          tilknyttedeDokumenter={klagebehandling.tilknyttedeDokumenter}
         />
         <AlleDokumenter
           skjult={!fullvisning}
           dokumenter={alleDokumenter}
-          visDokument={visDokument}
+          visDokument={settDokument}
           klagebehandling={klagebehandling}
         />
       </DokumenterBeholder>

--- a/frontend/src/komponenter/Klagebehandling/Dokumenter/Header.tsx
+++ b/frontend/src/komponenter/Klagebehandling/Dokumenter/Header.tsx
@@ -4,15 +4,19 @@ import styled from "styled-components";
 interface HeaderProps {
   settFullvisning: (fullvisning: boolean) => void;
   fullvisning: boolean;
+  antall: number;
 }
 
-export const Header = ({ fullvisning, settFullvisning }: HeaderProps) => (
-  <DokumenterNav>
-    <DokumenterTittel>Dokumenter</DokumenterTittel>
-    <VisTilknyttedeKnapp onClick={() => settFullvisning(!fullvisning)}>
-      {getText(fullvisning)}
-    </VisTilknyttedeKnapp>
-  </DokumenterNav>
+export const Header = React.memo<HeaderProps>(
+  ({ fullvisning, settFullvisning, antall }) => (
+    <DokumenterNav>
+      <DokumenterTittel>Dokumenter</DokumenterTittel>
+      <VisTilknyttedeKnapp onClick={() => settFullvisning(!fullvisning)}>
+        {getText(fullvisning)} ({antall})
+      </VisTilknyttedeKnapp>
+    </DokumenterNav>
+  ),
+  (previous, next) => previous.fullvisning === next.fullvisning && previous.antall === next.antall
 );
 
 const getText = (fullvisning: boolean) =>

--- a/frontend/src/komponenter/Klagebehandling/Dokumenter/ShowDokument.tsx
+++ b/frontend/src/komponenter/Klagebehandling/Dokumenter/ShowDokument.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from "react";
 import styled from "styled-components";
-import { IDokument } from "../../../tilstand/moduler/dokumenter/stateTypes";
+import { IShownDokument } from "./typer";
 // @ts-ignore
 import CloseSVG from "./ikoner/cancelblack.svg";
 // @ts-ignore
@@ -16,7 +16,7 @@ const ZOOM_STEP = 150;
 
 interface ShowDokumentProps {
   klagebehandlingId: string;
-  dokument: IDokument | null;
+  dokument: IShownDokument | null;
   close: () => void;
 }
 

--- a/frontend/src/komponenter/Klagebehandling/Dokumenter/TilknyttedeDokumenter.tsx
+++ b/frontend/src/komponenter/Klagebehandling/Dokumenter/TilknyttedeDokumenter.tsx
@@ -1,74 +1,167 @@
 import NavFrontendSpinner from "nav-frontend-spinner";
 import React, { useMemo } from "react";
+import styled from "styled-components";
 import { formattedDate } from "../../../domene/datofunksjoner";
-import { IDokument, IDokumentListe } from "../../../tilstand/moduler/dokumenter/stateTypes";
-import { IKlagebehandling } from "../../../tilstand/moduler/klagebehandling/stateTypes";
+import { useAppSelector } from "../../../tilstand/konfigurerTilstand";
+import { velgTilknyttedeDokumenter } from "../../../tilstand/moduler/dokumenter/selectors";
+import { IDokumentVedlegg } from "../../../tilstand/moduler/dokumenter/stateTypes";
+import { TilknyttetDokument } from "../../../tilstand/moduler/klagebehandling/types";
 import { dokumentMatcher } from "./helpers";
 import {
   DokumenterMinivisning,
   Tilknyttet,
   TilknyttetDato,
-  TilknyttetTittel,
+  TilknyttetKnapp,
 } from "./styled-components/minivisning";
-import { ITilknyttetDokument } from "./typer";
+import { IShownDokument, ITilknyttetDokument } from "./typer";
 
 interface TilknyttedeDokumenterProps {
-  dokumenter: IDokumentListe;
   skjult: boolean;
-  klagebehandling: IKlagebehandling;
-  visDokument: (dokument: IDokument) => void;
+  tilknyttedeDokumenter: TilknyttetDokument[];
+  visDokument: (dokument: IShownDokument) => void;
 }
 
-export const TilknyttedeDokumenter = ({
-  dokumenter,
-  visDokument,
-  klagebehandling,
-  skjult,
-}: TilknyttedeDokumenterProps) => {
-  const tilknyttedeDokumenter = useMemo<ITilknyttetDokument[]>(
-    () =>
-      dokumenter.loading
-        ? []
-        : dokumenter.dokumenter.map((dokument) => ({
-            dokument,
-            tilknyttet: klagebehandling.tilknyttedeDokumenter.some((t) =>
-              dokumentMatcher(t, dokument)
-            ),
-          })),
-    [dokumenter.dokumenter, dokumenter.loading, klagebehandling.tilknyttedeDokumenter]
-  );
-  if (skjult) {
-    return null;
-  }
+export const TilknyttedeDokumenter = React.memo(
+  ({ visDokument, tilknyttedeDokumenter, skjult }: TilknyttedeDokumenterProps) => {
+    const lagredeTilknyttedeDokumenter = useAppSelector(velgTilknyttedeDokumenter);
 
-  if (dokumenter.loading) {
-    return <NavFrontendSpinner />;
-  }
+    const dokumenter = useMemo<ITilknyttetDokument[]>(
+      () =>
+        lagredeTilknyttedeDokumenter.dokumenter
+          .map((dokument) => ({
+            dokument,
+            tilknyttet: tilknyttedeDokumenter.some((t) => dokumentMatcher(t, dokument)),
+          }))
+          .filter(({ dokument, tilknyttet }) => tilknyttet || dokument.vedlegg.length !== 0),
+      [tilknyttedeDokumenter, lagredeTilknyttedeDokumenter]
+    );
+
+    if (skjult || dokumenter.length === 0) {
+      return null;
+    }
+
+    return (
+      <Container>
+        <Loading loading={lagredeTilknyttedeDokumenter.loading} />
+        <DokumenterMinivisning>
+          {dokumenter.map(({ dokument, tilknyttet }) => (
+            <Tilknyttet key={dokument.journalpostId + dokument.dokumentInfoId}>
+              <TilknyttetDato dateTime={dokument.registrert}>
+                {formattedDate(dokument.registrert)}
+              </TilknyttetDato>
+              <TilknyttetKnapp
+                tilknyttet={tilknyttet}
+                onClick={() =>
+                  visDokument({
+                    journalpostId: dokument.journalpostId,
+                    dokumentInfoId: dokument.dokumentInfoId,
+                    tittel: dokument.tittel,
+                    harTilgangTilArkivvariant: dokument.harTilgangTilArkivvariant,
+                  })
+                }
+              >
+                {dokument.tittel}
+              </TilknyttetKnapp>
+              <VedleggListe
+                journalpostId={dokument.journalpostId}
+                vedleggListe={dokument.vedlegg}
+                tilknyttedeDokumenter={tilknyttedeDokumenter}
+                visDokument={visDokument}
+              />
+            </Tilknyttet>
+          ))}
+        </DokumenterMinivisning>
+      </Container>
+    );
+  },
+  (previous, next) =>
+    previous.skjult === next.skjult && previous.tilknyttedeDokumenter === next.tilknyttedeDokumenter
+);
+
+const Container = styled.div`
+  position: relative;
+`;
+
+interface VedleggListeProps {
+  vedleggListe: IDokumentVedlegg[];
+  tilknyttedeDokumenter: TilknyttetDokument[];
+  journalpostId: string;
+  visDokument: (dokument: IShownDokument) => void;
+}
+
+const VedleggListe = ({
+  vedleggListe,
+  tilknyttedeDokumenter,
+  journalpostId,
+  visDokument,
+}: VedleggListeProps) => {
+  const tilknyttedeVedlegg = useMemo<IDokumentVedlegg[]>(
+    () =>
+      vedleggListe.filter((vedlegg) =>
+        tilknyttedeDokumenter.some(
+          ({ dokumentInfoId }) => dokumentInfoId === vedlegg.dokumentInfoId
+        )
+      ),
+    [tilknyttedeDokumenter, vedleggListe]
+  );
 
   return (
     <DokumenterMinivisning>
-      {tilknyttedeDokumenter.map(({ dokument, tilknyttet }) => (
-        <Tilknyttet key={dokument.journalpostId + dokument.dokumentInfoId}>
-          <TilknyttetDato dateTime={dokument.registrert}>
-            {formattedDate(dokument.registrert)}
-          </TilknyttetDato>
-          <TilknyttetTittel tilknyttet={tilknyttet} onClick={() => visDokument(dokument)}>
-            {dokument.tittel}
-          </TilknyttetTittel>
-          <DokumenterMinivisning>
-            {dokument.vedlegg.map((vedlegg) => (
-              <Tilknyttet key={dokument.journalpostId + vedlegg.dokumentInfoId}>
-                <TilknyttetTittel
-                  tilknyttet={true}
-                  onClick={() => visDokument({ ...dokument, ...vedlegg })}
-                >
-                  {vedlegg.tittel}
-                </TilknyttetTittel>
-              </Tilknyttet>
-            ))}
-          </DokumenterMinivisning>
-        </Tilknyttet>
+      {tilknyttedeVedlegg.map((vedlegg) => (
+        <Vedlegg
+          key={journalpostId + vedlegg.dokumentInfoId}
+          journalpostId={journalpostId}
+          vedlegg={vedlegg}
+          visDokument={visDokument}
+        />
       ))}
     </DokumenterMinivisning>
   );
 };
+
+interface VedleggProps {
+  journalpostId: string;
+  vedlegg: IDokumentVedlegg;
+  visDokument: (dokument: IShownDokument) => void;
+}
+
+const Vedlegg = ({ journalpostId, vedlegg, visDokument }: VedleggProps) => (
+  <Tilknyttet>
+    <TilknyttetKnapp
+      tilknyttet={true}
+      onClick={() =>
+        visDokument({
+          journalpostId,
+          dokumentInfoId: vedlegg.dokumentInfoId,
+          tittel: vedlegg.tittel,
+          harTilgangTilArkivvariant: vedlegg.harTilgangTilArkivvariant,
+        })
+      }
+    >
+      {vedlegg.tittel}
+    </TilknyttetKnapp>
+  </Tilknyttet>
+);
+
+interface LoadingProps {
+  loading: boolean;
+}
+
+const Loading = ({ loading }: LoadingProps) =>
+  loading ? (
+    <SpinnerBackground>
+      <NavFrontendSpinner />
+    </SpinnerBackground>
+  ) : null;
+
+const SpinnerBackground = styled.div`
+  display: flex;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(255, 255, 255, 0.8);
+  justify-content: center;
+  padding: 1em;
+`;

--- a/frontend/src/komponenter/Klagebehandling/Dokumenter/styled-components/minivisning.tsx
+++ b/frontend/src/komponenter/Klagebehandling/Dokumenter/styled-components/minivisning.tsx
@@ -16,7 +16,7 @@ export const TilknyttetDato = styled.time`
   font-size: 12px;
 `;
 
-export const TilknyttetTittel = styled.button<{ tilknyttet: boolean }>`
+export const TilknyttetKnapp = styled.button<{ tilknyttet: boolean }>`
   display: block;
   cursor: pointer;
   padding: 0;

--- a/frontend/src/komponenter/Klagebehandling/Dokumenter/typer.ts
+++ b/frontend/src/komponenter/Klagebehandling/Dokumenter/typer.ts
@@ -9,3 +9,10 @@ export interface ITilknyttetVedlegg {
   vedlegg: IDokumentVedlegg;
   tilknyttet: boolean;
 }
+
+export interface IShownDokument {
+  journalpostId: string;
+  dokumentInfoId: string; // nullable?
+  tittel: string | null;
+  harTilgangTilArkivvariant: boolean;
+}

--- a/frontend/src/komponenter/Klagebehandling/Topplinje/AutolagreElement.tsx
+++ b/frontend/src/komponenter/Klagebehandling/Topplinje/AutolagreElement.tsx
@@ -26,29 +26,32 @@ const AutosaveContent = styled.div`
   align-items: center;
 `;
 
-const LagringsIndikator = (props: Props) => {
-  const [anker, setAnker] = useState<(EventTarget & HTMLDivElement) | undefined>(undefined);
-  const togglePopover = (ankerEl: EventTarget & HTMLDivElement): void =>
-    setAnker(anker ? undefined : ankerEl);
+const LagringsIndikator = React.memo<Props>(
+  ({ autosaveStatus }) => {
+    const [anker, setAnker] = useState<(EventTarget & HTMLDivElement) | undefined>(undefined);
+    const togglePopover = (ankerEl: EventTarget & HTMLDivElement): void =>
+      setAnker(anker ? undefined : ankerEl);
 
-  return (
-    <>
-      <Popover
-        ankerEl={anker}
-        onRequestClose={() => setAnker(undefined)}
-        orientering={PopoverOrientering.UnderHoyre}
-      >
-        <p style={{ padding: "16px" }}>Endringene lagres automatisk.</p>
-      </Popover>
+    return (
+      <>
+        <Popover
+          ankerEl={anker}
+          onRequestClose={() => setAnker(undefined)}
+          orientering={PopoverOrientering.UnderHoyre}
+        >
+          <p style={{ padding: "16px" }}>Endringene lagres automatisk.</p>
+        </Popover>
 
-      <AutoLagreBeholder>
-        <AutosaveContent onClick={(e) => togglePopover(e.currentTarget)}>
-          {visStatus(props.autosaveStatus)}
-        </AutosaveContent>
-      </AutoLagreBeholder>
-    </>
-  );
-};
+        <AutoLagreBeholder>
+          <AutosaveContent onClick={(e) => togglePopover(e.currentTarget)}>
+            {visStatus(autosaveStatus)}
+          </AutosaveContent>
+        </AutoLagreBeholder>
+      </>
+    );
+  },
+  (previous, next) => previous.autosaveStatus === next.autosaveStatus
+);
 
 const visStatus = (status: boolean) => {
   if (status) {

--- a/frontend/src/komponenter/Klagebehandling/Topplinje/EksterneLenker.tsx
+++ b/frontend/src/komponenter/Klagebehandling/Topplinje/EksterneLenker.tsx
@@ -8,33 +8,41 @@ import { useIsSaved } from "../utils/hooks";
 
 interface EksterneLenkerProps {
   fnr: string | null;
-  id: string;
 }
 
-export default function EksterneLenker({ id, fnr }: EksterneLenkerProps) {
-  if (fnr === null) {
-    return null;
-  }
+export const EksterneLenker = React.memo(
+  ({ fnr }: EksterneLenkerProps) => {
+    if (fnr === null) {
+      return null;
+    }
+
+    return (
+      <Knapper>
+        <Knapperad>
+          <Lenke
+            target="_blank"
+            aria-label={"Ekstern lenke til Gosys for denne personen"}
+            href={`${gosysEnvironment(window.location.hostname)}/personoversikt/fnr=${fnr}`}
+          >
+            Gosys&nbsp;
+            <Ikon alt="Ekstern lenke" src={ExtLink} />
+          </Lenke>
+        </Knapperad>
+        <LagretStatus />
+      </Knapper>
+    );
+  },
+  (previous, next) => previous.fnr === next.fnr
+);
+
+const LagretStatus = () => {
   const isSaved = useIsSaved();
-
   return (
-    <Knapper>
-      <Knapperad>
-        <Lenke
-          target="_blank"
-          aria-label={"Ekstern lenke til Gosys for denne personen"}
-          href={`${gosysEnvironment(window.location.hostname)}/personoversikt/fnr=${fnr}`}
-        >
-          Gosys&nbsp;
-          <Ikon alt="Ekstern lenke" src={ExtLink} />
-        </Lenke>
-      </Knapperad>
-      <Knapperad>
-        <LagringsIndikator autosaveStatus={!isSaved} />
-      </Knapperad>
-    </Knapper>
+    <Knapperad>
+      <LagringsIndikator autosaveStatus={!isSaved} />
+    </Knapperad>
   );
-}
+};
 
 const Knapper = styled.div`
   display: flex;

--- a/frontend/src/komponenter/Klagebehandling/Topplinje/Kontrollpanel.tsx
+++ b/frontend/src/komponenter/Klagebehandling/Topplinje/Kontrollpanel.tsx
@@ -2,7 +2,7 @@ import React, { useCallback } from "react";
 import styled from "styled-components";
 import { IKlagebehandling } from "../../../tilstand/moduler/klagebehandling/stateTypes";
 import { IFaner } from "../KlageBehandling";
-import EksterneLenker from "./EksterneLenker";
+import { EksterneLenker } from "./EksterneLenker";
 // @ts-ignore
 import IkonMann from "../../mann.svg";
 // @ts-ignore
@@ -75,7 +75,7 @@ export const Topplinje = ({ klagebehandling, faner, settAktiveFaner }: Topplinje
         />
       </Knapper>
 
-      <EksterneLenker id={klagebehandling.id} fnr={klagebehandling.sakenGjelderFoedselsnummer} />
+      <EksterneLenker fnr={klagebehandling.sakenGjelderFoedselsnummer} />
     </Kontrollpanel>
   );
 };

--- a/frontend/src/komponenter/Klagebehandling/utils/hooks.test.ts
+++ b/frontend/src/komponenter/Klagebehandling/utils/hooks.test.ts
@@ -1,0 +1,48 @@
+import { clone } from "ramda";
+import { IKlagebehandlingOppdatering } from "../../../tilstand/moduler/klagebehandling/types";
+import { isEqual } from "./hooks";
+
+describe("Klagebehandling oppdatering isEqual", () => {
+  const getBaseOppdatering = (): IKlagebehandlingOppdatering => ({
+    internVurdering: "internVurdering",
+    klagebehandlingId: "klagebehandlingId",
+    klagebehandlingVersjon: 1,
+    tilknyttedeDokumenter: [],
+    vedtak: [
+      {
+        grunn: "vedtak.grunn",
+        brevMottakere: [],
+        ferdigstilt: null,
+        file: null,
+        hjemler: [],
+        id: "vedtak.id",
+        opplastet: null,
+        utfall: "vedtak.utfall",
+      },
+    ],
+  });
+
+  test("Like behandlinger er like", () => {
+    const oppdatering = getBaseOppdatering();
+    const enAnnenOppdatering = clone(oppdatering);
+    expect(oppdatering).not.toBe(enAnnenOppdatering);
+    const actual = isEqual(oppdatering, enAnnenOppdatering);
+    expect(actual).toBe(true);
+  });
+
+  test("Behandlinger med forskjellige dokumenter er ikke like", () => {
+    const oppdatering = getBaseOppdatering();
+    oppdatering.tilknyttedeDokumenter.push({
+      journalpostId: "journalpostId-1",
+      dokumentInfoId: "dokumentInfoId-1",
+    });
+    const enAnnenOppdatering = clone(oppdatering);
+    enAnnenOppdatering.tilknyttedeDokumenter.push({
+      journalpostId: "journalpostId-2",
+      dokumentInfoId: "dokumentInfoId-2",
+    });
+    expect(oppdatering).not.toBe(enAnnenOppdatering);
+    const actual = isEqual(oppdatering, enAnnenOppdatering);
+    expect(actual).toBe(false);
+  });
+});

--- a/frontend/src/komponenter/Oppsett.tsx
+++ b/frontend/src/komponenter/Oppsett.tsx
@@ -1,10 +1,10 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Header } from "./Header/Header";
 import Alertstripe from "nav-frontend-alertstriper";
 import { useSelector } from "react-redux";
 import PropTypes from "prop-types";
-import Cookies from "js-cookie";
-import { NavLink, Redirect } from "react-router-dom";
+import { NavLink } from "react-router-dom";
+import * as R from "ramda";
 import { velgMeg } from "../tilstand/moduler/meg.velgere";
 import { velgFeatureToggles } from "../tilstand/moduler/unleash.velgere";
 import { velgToaster, velgToasterMelding } from "../tilstand/moduler/toaster.velgere";
@@ -19,8 +19,6 @@ import isDevLocation from "../utility/isDevLocation";
 import useInterval from "../utility/useInterval";
 import { hentToken, sjekkAuth } from "../tilstand/moduler/auth";
 import { velgAuth } from "../tilstand/moduler/auth.velgere";
-
-const R = require("ramda");
 
 interface LayoutType {
   visMeny: boolean;

--- a/frontend/src/tilstand/moduler/dokumenter/actions.ts
+++ b/frontend/src/tilstand/moduler/dokumenter/actions.ts
@@ -1,9 +1,5 @@
 import { createAction } from "@reduxjs/toolkit";
-import { IDokument } from "./stateTypes";
 import { IDokumenterParams } from "./types";
 
 export const hentDokumenter = createAction<IDokumenterParams>("dokumenter/HENT");
 export const hentTilknyttedeDokumenter = createAction<string>("dokumenter/HENT_TILKNYTTEDE");
-
-export const tilknyttDokument = createAction<IDokument>("dokumenter/TILKNYTT");
-export const frakobleDokument = createAction<IDokument>("dokumenter/FRAKOBLE");

--- a/frontend/src/tilstand/moduler/dokumenter/epics.ts
+++ b/frontend/src/tilstand/moduler/dokumenter/epics.ts
@@ -5,27 +5,15 @@ import { catchError, map, mergeMap, retryWhen, timeout } from "rxjs/operators";
 import { provIgjenStrategi } from "../../../utility/rxUtils";
 import { Dependencies } from "../../konfigurerTilstand";
 import { RootState } from "../../root";
-import {
-  TILKNYTT_DOKUMENT as TILKNYTT_DOKUMENT_TIL_BEHANDLING,
-  FRAKOBLE_DOKUMENT as FRAKOBLE_DOKUMENT_FRA_BEHANDLING,
-} from "../klagebehandling/state";
 import { toasterSett, toasterSkjul } from "../toaster";
-import {
-  frakobleDokument,
-  hentDokumenter,
-  hentTilknyttedeDokumenter,
-  tilknyttDokument,
-} from "./actions";
+import { hentDokumenter, hentTilknyttedeDokumenter } from "./actions";
 import {
   ERROR,
   DOKUMENTER_LOADING,
   LEGG_TIL_DOKUMENTER,
-  TILKNYTT_DOKUMENT,
-  FRAKOBLE_DOKUMENT,
   SETT_TILKNYTTEDE_DOKUMENTER,
   TILKNYTTEDE_DOKUMENTER_LOADING,
 } from "./state";
-import { IDokument } from "./stateTypes";
 import { IDokumenterParams, IDokumenterRespons } from "./types";
 
 export const loadingDokumenterEpic = (action$: ActionsObservable<PayloadAction<never>>) =>
@@ -95,41 +83,5 @@ export const hentTilknyttedeDokumenterEpic = (
             )
           )
         )
-    )
-  );
-
-export const tilknyttDokumentEpic = (
-  action$: ActionsObservable<PayloadAction<IDokument>>,
-  _: StateObservable<RootState> | null,
-  __: Dependencies
-) =>
-  action$.pipe(
-    ofType(tilknyttDokument.type),
-    mergeMap(({ payload }) =>
-      of(
-        TILKNYTT_DOKUMENT_TIL_BEHANDLING({
-          dokumentInfoId: payload.dokumentInfoId,
-          journalpostId: payload.journalpostId,
-        }),
-        TILKNYTT_DOKUMENT(payload)
-      )
-    )
-  );
-
-export const frakobleDokumentEpic = (
-  action$: ActionsObservable<PayloadAction<IDokument>>,
-  _: StateObservable<RootState> | null,
-  __: Dependencies
-) =>
-  action$.pipe(
-    ofType(frakobleDokument.type),
-    mergeMap(({ payload }) =>
-      of(
-        FRAKOBLE_DOKUMENT_FRA_BEHANDLING({
-          dokumentInfoId: payload.dokumentInfoId,
-          journalpostId: payload.journalpostId,
-        }),
-        FRAKOBLE_DOKUMENT(payload)
-      )
     )
   );

--- a/frontend/src/tilstand/moduler/dokumenter/state.ts
+++ b/frontend/src/tilstand/moduler/dokumenter/state.ts
@@ -1,16 +1,15 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import {
-  frakobleDokumentEpic,
   hentDokumenterEpic,
   hentTilknyttedeDokumenterEpic,
   loadingDokumenterEpic,
-  tilknyttDokumentEpic,
+  loadingTilknyttedeDokumenterEpic,
 } from "./epics";
 import { initialState } from "./initialState";
 import { IDokument } from "./stateTypes";
 import { IDokumenterRespons } from "./types";
 
-export const sorterSynkendePaaRegistrert = (dokumenter: IDokument[]) => {
+const sorterSynkendePaaRegistrert = (dokumenter: IDokument[]) => {
   if (dokumenter.length === 0) {
     return [];
   }
@@ -40,30 +39,9 @@ export const dokumenterSlice = createSlice({
       state.dokumenter.loading = false;
       return state;
     },
-    SETT_TILKNYTTEDE_DOKUMENTER: (state, action: PayloadAction<IDokument[]>) => {
-      state.tilknyttedeDokumenter.dokumenter = sorterSynkendePaaRegistrert(action.payload);
+    SETT_TILKNYTTEDE_DOKUMENTER: (state, { payload }: PayloadAction<IDokument[]>) => {
+      state.tilknyttedeDokumenter.dokumenter = sorterSynkendePaaRegistrert(payload);
       state.tilknyttedeDokumenter.loading = false;
-      return state;
-    },
-    TILKNYTT_DOKUMENT: (state, { payload }: PayloadAction<IDokument>) => {
-      const exists = state.tilknyttedeDokumenter.dokumenter.some(
-        (e) =>
-          e.dokumentInfoId === payload.dokumentInfoId && e.journalpostId === payload.journalpostId
-      );
-      if (exists) {
-        return state;
-      }
-      state.tilknyttedeDokumenter.dokumenter = sorterSynkendePaaRegistrert([
-        ...state.tilknyttedeDokumenter.dokumenter,
-        payload,
-      ]);
-      return state;
-    },
-    FRAKOBLE_DOKUMENT: (state, { payload }: PayloadAction<IDokument>) => {
-      state.tilknyttedeDokumenter.dokumenter = state.tilknyttedeDokumenter.dokumenter.filter(
-        ({ dokumentInfoId, journalpostId }) =>
-          !(dokumentInfoId === payload.dokumentInfoId && journalpostId === payload.journalpostId)
-      );
       return state;
     },
     DOKUMENTER_LOADING: (state) => {
@@ -88,17 +66,14 @@ export const {
   TILKNYTTEDE_DOKUMENTER_LOADING,
   ERROR,
   NULLSTILL_DOKUMENTER,
-  TILKNYTT_DOKUMENT,
-  FRAKOBLE_DOKUMENT,
   SETT_TILKNYTTEDE_DOKUMENTER,
 } = dokumenterSlice.actions;
 
 export const DOKUMENTER_EPICS = [
   hentDokumenterEpic,
   hentTilknyttedeDokumenterEpic,
-  tilknyttDokumentEpic,
-  frakobleDokumentEpic,
   loadingDokumenterEpic,
+  loadingTilknyttedeDokumenterEpic,
 ];
 
 export const dokumenter = dokumenterSlice.reducer;

--- a/frontend/src/tilstand/moduler/klagebehandling/epics.ts
+++ b/frontend/src/tilstand/moduler/klagebehandling/epics.ts
@@ -5,6 +5,7 @@ import { catchError, map, mergeMap, retryWhen, switchMap, timeout } from "rxjs/o
 import { provIgjenStrategi } from "../../../utility/rxUtils";
 import { Dependencies } from "../../konfigurerTilstand";
 import { RootState } from "../../root";
+import { hentTilknyttedeDokumenter } from "../dokumenter/actions";
 import { toasterSett, toasterSkjul } from "../toaster";
 import { hentKlagebehandling, lagreKlagebehandling, unloadKlagebehandling } from "./actions";
 import {
@@ -63,12 +64,12 @@ export const lagreKlagebehandlingEpic = (
           }
         )
         .pipe(
-          map(({ response }) => {
-            console.debug("EDITABLE FIELDS RESPONSE", response);
-            return response;
-          }),
-          map((response: IKlagebehandlingOppdateringResponse) =>
-            KLAGEBEHANDLING_LAGRET({ ...payload, ...response })
+          map(({ response }) => response),
+          mergeMap((response: IKlagebehandlingOppdateringResponse) =>
+            of(
+              KLAGEBEHANDLING_LAGRET({ ...payload, ...response }),
+              hentTilknyttedeDokumenter(payload.klagebehandlingId)
+            )
           )
         )
         .pipe(
@@ -86,7 +87,7 @@ export const lagreKlagebehandlingEpic = (
           })
         )
     ),
-    mergeMap((res) => of(LEDIG(), res))
+    mergeMap((res) => of(res, LEDIG()))
   );
 
 const createPayload = ({


### PR DESCRIPTION
Denne PRen ble større enn planlagt siden dokumenter ikke fungerer i dev.

Den gjør følgende:
- Fikser en bug som gjorde at knytting og fradeling av vedlegg og dokumenter ikke fungerte som forventet.
- Forbedrer ytelsen ved mange dokumenter. Det ble veldig tregt tidligere.
- Endrer mock APIet til å støtte dokumenter og vedlegg som forventet. Ingen tilfeldige vedlegg f.eks.
- Rydder opp og fjerner irrelevante tester.

PRen aktiverer også Prettier for `api-mock-server`.