### PR TITLE
Fix bug where frame times would log big values if tab was unfocused b…

### DIFF
--- a/frontend/src/frame-times.ts
+++ b/frontend/src/frame-times.ts
@@ -13,15 +13,14 @@ class FrameTimes {
   private isRunning = false;
   private currentAnimationFrame: number | null = null;
 
-  public constructor() {
-    document.addEventListener('visibilitychange', () => this.onVisibilityChange());
-  }
-
   public async init() {
+    await delay(10_000);
+
     if (!document.hidden) {
-      await delay(10_000);
       this.start();
     }
+
+    document.addEventListener('visibilitychange', () => this.onVisibilityChange());
   }
 
   private runMeasureLoop(previousTime: number = getNow()) {


### PR DESCRIPTION
…etween init and the next ten seconds