### PR TITLE
Add route protection and no access page

### DIFF
--- a/frontend/src/components/app/no-access-page.tsx
+++ b/frontend/src/components/app/no-access-page.tsx
@@ -1,9 +1,10 @@
 import { BodyShort, Heading, Tag } from '@navikt/ds-react';
-import { useContext } from 'react';
+import { useContext, useEffect } from 'react';
 import { styled } from 'styled-components';
 import { StaticDataContext } from '@app/components/app/static-data-context';
 import { RoleList } from '@app/components/role-list/role-list';
 import { ENVIRONMENT } from '@app/environment';
+import { pushEvent } from '@app/observability';
 import { PageWrapper } from '@app/pages/page-wrapper';
 import { ALL_NORMAL_ROLES, Role } from '@app/types/bruker';
 
@@ -17,6 +18,14 @@ const INSTRUCTION = ENVIRONMENT.isProduction
 
 export const NoAccessPage = ({ requiredRoles }: Props) => {
   const { user } = useContext(StaticDataContext);
+
+  useEffect(() => {
+    pushEvent('no-access-page', {
+      userRoles: user.roller.toSorted().join(', '),
+      requiredRoles: requiredRoles.toSorted().join(', '),
+      path: window.location.pathname,
+    });
+  }, [requiredRoles, user.roller]);
 
   return (
     <PageWrapper>

--- a/frontend/src/components/app/no-access-page.tsx
+++ b/frontend/src/components/app/no-access-page.tsx
@@ -1,0 +1,63 @@
+import { BodyShort, Heading, Tag } from '@navikt/ds-react';
+import { useContext } from 'react';
+import { styled } from 'styled-components';
+import { StaticDataContext } from '@app/components/app/static-data-context';
+import { RoleList } from '@app/components/role-list/role-list';
+import { ENVIRONMENT } from '@app/environment';
+import { PageWrapper } from '@app/pages/page-wrapper';
+import { ALL_NORMAL_ROLES, Role } from '@app/types/bruker';
+
+interface Props {
+  requiredRoles: Role[];
+}
+
+const INSTRUCTION = ENVIRONMENT.isProduction
+  ? 'Be din leder om å tildele deg nødvendig rolle.'
+  : 'Tildel din testbruker nødvendig rolle eller benytt en annen testbruker.';
+
+export const NoAccessPage = ({ requiredRoles }: Props) => {
+  const { user } = useContext(StaticDataContext);
+
+  return (
+    <PageWrapper>
+      <Centered>
+        <Heading level="1" size="medium" spacing>
+          Din bruker har ikke tilgang til denne siden
+        </Heading>
+        <BodyShort spacing>
+          Din bruker har ikke den nødvendige rollen for å få tilgang til <Path />.
+        </BodyShort>
+
+        <RoleList
+          title="Minst én av følgende roller kreves for å se denne siden"
+          description={INSTRUCTION}
+          roles={requiredRoles}
+          variant="warning-moderate"
+        />
+
+        <RoleList title="Roller brukeren din har nå" roles={user.roller} variant="info-moderate" />
+
+        <RoleList
+          title="Andre roller Kabal bruker"
+          roles={ALL_NORMAL_ROLES.filter((r) => !user.roller.includes(r) && !requiredRoles.includes(r))}
+          variant="neutral-moderate"
+        />
+      </Centered>
+    </PageWrapper>
+  );
+};
+
+const Path = () => (
+  <Tag variant="neutral-moderate" size="xsmall">
+    <StyledPre>{window.location.pathname}</StyledPre>
+  </Tag>
+);
+
+const StyledPre = styled.pre`
+  margin: 0;
+`;
+
+const Centered = styled.div`
+  margin: 0 auto;
+  width: fit-content;
+`;

--- a/frontend/src/components/app/not-found-page.tsx
+++ b/frontend/src/components/app/not-found-page.tsx
@@ -1,0 +1,24 @@
+import { BodyShort, Heading, Tag } from '@navikt/ds-react';
+import { styled } from 'styled-components';
+import { PageWrapper } from '@app/pages/page-wrapper';
+
+export const NotFoundPage = () => (
+  <PageWrapper>
+    <Heading level="1" size="medium">
+      Siden finnes ikke
+    </Heading>
+    <BodyShort>
+      Siden <Path /> finnes ikke.
+    </BodyShort>
+  </PageWrapper>
+);
+
+const Path = () => (
+  <Tag variant="neutral-moderate" size="xsmall">
+    <StyledPre>{window.location.pathname}</StyledPre>
+  </Tag>
+);
+
+const StyledPre = styled.pre`
+  margin: 0;
+`;

--- a/frontend/src/components/app/protected-route.tsx
+++ b/frontend/src/components/app/protected-route.tsx
@@ -1,0 +1,20 @@
+import { useContext } from 'react';
+import { Outlet } from 'react-router-dom';
+import { NoAccessPage } from '@app/components/app/no-access-page';
+import { StaticDataContext } from '@app/components/app/static-data-context';
+import { Role } from '@app/types/bruker';
+
+interface Props {
+  roles: Role[];
+}
+
+export const ProtectedRoute = ({ roles }: Props) => {
+  const { user } = useContext(StaticDataContext);
+  const hasRole = user.roller.some((r) => roles.includes(r));
+
+  if (hasRole) {
+    return <Outlet />;
+  }
+
+  return <NoAccessPage requiredRoles={roles} />;
+};

--- a/frontend/src/components/app/router.tsx
+++ b/frontend/src/components/app/router.tsx
@@ -1,4 +1,6 @@
 import { Route, Routes as Switch } from 'react-router-dom';
+import { NotFoundPage } from '@app/components/app/not-found-page';
+import { ProtectedRoute } from '@app/components/app/protected-route';
 import { AccessRightsPage } from '@app/pages/access-rights/access-rights';
 import { AdminPage } from '@app/pages/admin/admin';
 import { AnkebehandlingPage } from '@app/pages/ankebehandling/ankebehandling';
@@ -17,62 +19,83 @@ import { SearchPage } from '@app/pages/search/search';
 import { SettingsPage } from '@app/pages/settings/settings';
 import { ToppteksterPage } from '@app/pages/topptekster/topptekster';
 import { TrygderettsankebehandlingPage } from '@app/pages/trygderettsankebehandling/trygderettsankebehandling';
+import { Role } from '@app/types/bruker';
 
 export const Router = () => (
   <Switch>
     <Route path="/" element={<LandingPage />} />
 
-    <Route path="oppgaver" element={<OppgaverPage />} />
+    <Route element={<ProtectedRoute roles={[Role.KABAL_SAKSBEHANDLING, Role.KABAL_ROL]} />}>
+      <Route path="oppgaver" element={<OppgaverPage />} />
+      <Route path="mineoppgaver" element={<MineOppgaverPage />} />
+      <Route path="klagebehandling/:id" element={<KlagebehandlingPage />} />
+      <Route path="ankebehandling/:id" element={<AnkebehandlingPage />} />
+      <Route path="trygderettsankebehandling/:id" element={<TrygderettsankebehandlingPage />} />
+    </Route>
 
-    <Route path="mineoppgaver" element={<MineOppgaverPage />} />
-    <Route path="oppgavestyring" element={<OppgavestyringPage />} />
+    <Route element={<ProtectedRoute roles={[Role.KABAL_INNSYN_EGEN_ENHET, Role.KABAL_KROL]} />}>
+      <Route path="oppgavestyring" element={<OppgavestyringPage />} />
+    </Route>
 
-    <Route path="sok" element={<SearchPage />} />
+    <Route element={<ProtectedRoute roles={[Role.KABAL_SAKSBEHANDLING, Role.KABAL_OPPGAVESTYRING_ALLE_ENHETER]} />}>
+      <Route path="sok" element={<SearchPage />} />
+    </Route>
 
-    <Route path="klagebehandling/:id" element={<KlagebehandlingPage />} />
-    <Route path="ankebehandling/:id" element={<AnkebehandlingPage />} />
-    <Route path="trygderettsankebehandling/:id" element={<TrygderettsankebehandlingPage />} />
+    <Route element={<ProtectedRoute roles={[Role.KABAL_MALTEKSTREDIGERING]} />}>
+      <Route
+        path="maltekstseksjoner/:lang/:id/versjoner/:maltekstseksjonVersionId/tekster/:textId"
+        element={<MaltekstseksjonerPage />}
+      />
+      <Route
+        path="maltekstseksjoner/:lang/:id/versjoner/:maltekstseksjonVersionId"
+        element={<MaltekstseksjonerPage />}
+      />
+      <Route path="maltekstseksjoner/:lang/:id" element={<MaltekstseksjonerPage />} />
+      <Route path="maltekstseksjoner/:lang" element={<MaltekstseksjonerPage />} />
+      <Route path="maltekstseksjoner" element={<MaltekstseksjonerPage />} />
 
-    <Route
-      path="maltekstseksjoner/:lang/:id/versjoner/:maltekstseksjonVersionId/tekster/:textId"
-      element={<MaltekstseksjonerPage />}
-    />
-    <Route path="maltekstseksjoner/:lang/:id/versjoner/:maltekstseksjonVersionId" element={<MaltekstseksjonerPage />} />
-    <Route path="maltekstseksjoner/:lang/:id" element={<MaltekstseksjonerPage />} />
-    <Route path="maltekstseksjoner/:lang" element={<MaltekstseksjonerPage />} />
-    <Route path="maltekstseksjoner" element={<MaltekstseksjonerPage />} />
+      <Route path="maltekster/:lang/:id/versjoner/:versionId" element={<MalteksterPage />} />
+      <Route path="maltekster/:lang/:id" element={<MalteksterPage />} />
+      <Route path="maltekster/:lang" element={<MalteksterPage />} />
+      <Route path="maltekster" element={<MalteksterPage />} />
 
-    <Route path="maltekster/:lang/:id/versjoner/:versionId" element={<MalteksterPage />} />
-    <Route path="maltekster/:lang/:id" element={<MalteksterPage />} />
-    <Route path="maltekster/:lang" element={<MalteksterPage />} />
-    <Route path="maltekster" element={<MalteksterPage />} />
+      <Route path="redigerbare-maltekster/:lang/:id/versjoner/:versionId" element={<RedigerbareMalteksterPage />} />
+      <Route path="redigerbare-maltekster/:lang/:id" element={<RedigerbareMalteksterPage />} />
+      <Route path="redigerbare-maltekster/:lang" element={<RedigerbareMalteksterPage />} />
+      <Route path="redigerbare-maltekster" element={<RedigerbareMalteksterPage />} />
 
-    <Route path="redigerbare-maltekster/:lang/:id/versjoner/:versionId" element={<RedigerbareMalteksterPage />} />
-    <Route path="redigerbare-maltekster/:lang/:id" element={<RedigerbareMalteksterPage />} />
-    <Route path="redigerbare-maltekster/:lang" element={<RedigerbareMalteksterPage />} />
-    <Route path="redigerbare-maltekster" element={<RedigerbareMalteksterPage />} />
+      <Route path="topptekster/:lang/:id/versjoner/:versionId" element={<ToppteksterPage />} />
+      <Route path="topptekster/:lang/:id" element={<ToppteksterPage />} />
+      <Route path="topptekster/:lang" element={<ToppteksterPage />} />
+      <Route path="topptekster" element={<ToppteksterPage />} />
 
-    <Route path="gode-formuleringer/:lang/:id/versjoner/:versionId" element={<GodeFormuleringerPage />} />
-    <Route path="gode-formuleringer/:lang/:id" element={<GodeFormuleringerPage />} />
-    <Route path="gode-formuleringer/:lang" element={<GodeFormuleringerPage />} />
-    <Route path="gode-formuleringer" element={<GodeFormuleringerPage />} />
+      <Route path="bunntekster/:lang/:id/versjoner/:versionId" element={<BunnteksterPage />} />
+      <Route path="bunntekster/:lang/:id" element={<BunnteksterPage />} />
+      <Route path="bunntekster/:lang" element={<BunnteksterPage />} />
+      <Route path="bunntekster" element={<BunnteksterPage />} />
+    </Route>
 
-    <Route path="topptekster/:lang/:id/versjoner/:versionId" element={<ToppteksterPage />} />
-    <Route path="topptekster/:lang/:id" element={<ToppteksterPage />} />
-    <Route path="topptekster/:lang" element={<ToppteksterPage />} />
-    <Route path="topptekster" element={<ToppteksterPage />} />
+    <Route element={<ProtectedRoute roles={[Role.KABAL_FAGTEKSTREDIGERING]} />}>
+      <Route path="gode-formuleringer/:lang/:id/versjoner/:versionId" element={<GodeFormuleringerPage />} />
+      <Route path="gode-formuleringer/:lang/:id" element={<GodeFormuleringerPage />} />
+      <Route path="gode-formuleringer/:lang" element={<GodeFormuleringerPage />} />
+      <Route path="gode-formuleringer" element={<GodeFormuleringerPage />} />
 
-    <Route path="bunntekster/:lang/:id/versjoner/:versionId" element={<BunnteksterPage />} />
-    <Route path="bunntekster/:lang/:id" element={<BunnteksterPage />} />
-    <Route path="bunntekster/:lang" element={<BunnteksterPage />} />
-    <Route path="bunntekster" element={<BunnteksterPage />} />
+      <Route path="regelverk/:id/versjoner/:versionId" element={<RegelverkPage />} />
+      <Route path="regelverk/:id" element={<RegelverkPage />} />
+      <Route path="regelverk" element={<RegelverkPage />} />
+    </Route>
 
-    <Route path="regelverk/:id/versjoner/:versionId" element={<RegelverkPage />} />
-    <Route path="regelverk/:id" element={<RegelverkPage />} />
-    <Route path="regelverk" element={<RegelverkPage />} />
+    <Route element={<ProtectedRoute roles={[Role.KABAL_TILGANGSSTYRING_EGEN_ENHET]} />}>
+      <Route path="tilgangsstyring" element={<AccessRightsPage />} />
+    </Route>
+
+    <Route element={<ProtectedRoute roles={[Role.KABAL_ADMIN]} />}>
+      <Route path="admin" element={<AdminPage />} />
+    </Route>
 
     <Route path="innstillinger" element={<SettingsPage />} />
-    <Route path="tilgangsstyring" element={<AccessRightsPage />} />
-    <Route path="admin" element={<AdminPage />} />
+
+    <Route path="*" element={<NotFoundPage />} />
   </Switch>
 );

--- a/frontend/src/components/nav/nav.tsx
+++ b/frontend/src/components/nav/nav.tsx
@@ -24,9 +24,11 @@ export const Nav = () => (
       <NavItem to="/oppgaver" testId="oppgaver-nav-link" roles={[Role.KABAL_SAKSBEHANDLING, Role.KABAL_ROL]}>
         <BulletListIcon /> Oppgaver
       </NavItem>
+
       <NavItem to="/mineoppgaver" testId="mine-oppgaver-nav-link" roles={[Role.KABAL_SAKSBEHANDLING, Role.KABAL_ROL]}>
         <TasklistIcon /> Mine Oppgaver
       </NavItem>
+
       <NavItem
         to="/sok"
         testId="search-nav-link"
@@ -34,6 +36,7 @@ export const Nav = () => (
       >
         <MagnifyingGlassIcon /> Søk på person
       </NavItem>
+
       <NavItem
         to="/oppgavestyring"
         testId="oppgavestyring-nav-link"

--- a/frontend/src/components/role-list/role-list-item.tsx
+++ b/frontend/src/components/role-list/role-list-item.tsx
@@ -1,0 +1,33 @@
+import { FilesIcon } from '@navikt/aksel-icons';
+import { Tag, TagProps, Tooltip } from '@navikt/ds-react';
+import { styled } from 'styled-components';
+import { ROLE_NAMES, Role } from '@app/types/bruker';
+
+interface Props {
+  role: Role;
+  variant: TagProps['variant'];
+}
+
+export const RoleItem = ({ role, variant }: Props) => {
+  const formattedRole = ROLE_NAMES[role];
+
+  return (
+    <Tooltip key={role} content="Kopier">
+      <RoleContent onClick={() => navigator.clipboard.writeText(formattedRole)}>
+        <Tag variant={variant} size="small">
+          {formattedRole} <FilesIcon aria-hidden />
+        </Tag>
+      </RoleContent>
+    </Tooltip>
+  );
+};
+
+const RoleContent = styled.button`
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  cursor: pointer;
+  margin: 0;
+  padding: 0;
+  border: none;
+`;

--- a/frontend/src/components/role-list/role-list.tsx
+++ b/frontend/src/components/role-list/role-list.tsx
@@ -1,0 +1,46 @@
+import { Heading, List, TagProps } from '@navikt/ds-react';
+import { styled } from 'styled-components';
+import { RoleItem } from '@app/components/role-list/role-list-item';
+import { Role } from '@app/types/bruker';
+
+interface Props {
+  roles: Role[];
+  title: string;
+  description?: string;
+  variant: TagProps['variant'];
+}
+
+export const RoleList = ({ roles, variant, title, description }: Props) => {
+  if (roles.length === 0) {
+    return (
+      <StyledSection>
+        <Heading level="3" size="xsmall" spacing>
+          {title}
+        </Heading>
+        <em>Ingen roller</em>
+      </StyledSection>
+    );
+  }
+
+  return (
+    <StyledList size="small" title={title} description={description}>
+      {roles.map((r) => (
+        <StyledListItem key={r}>
+          <RoleItem key={r} role={r} variant={variant} />
+        </StyledListItem>
+      ))}
+    </StyledList>
+  );
+};
+
+const StyledList = styled(List)`
+  width: fit-content;
+`;
+
+const StyledListItem = styled(List.Item)`
+  width: fit-content;
+`;
+
+const StyledSection = styled.section`
+  margin-block: var(--a-spacing-3);
+`;

--- a/frontend/src/pages/landing-page/landing-page.tsx
+++ b/frontend/src/pages/landing-page/landing-page.tsx
@@ -1,9 +1,20 @@
-import { ErrorMessage } from '@navikt/ds-react';
+import { BodyShort, Heading } from '@navikt/ds-react';
+import { useContext } from 'react';
 import { Navigate } from 'react-router-dom';
+import { styled } from 'styled-components';
+import { StaticDataContext } from '@app/components/app/static-data-context';
+import { RoleList } from '@app/components/role-list/role-list';
+import { ENVIRONMENT } from '@app/environment';
 import { useLandingPagePath } from '@app/hooks/use-landing-page-path';
-import { PageWrapper } from '../page-wrapper';
+import { PageWrapper } from '@app/pages/page-wrapper';
+import { ALL_NORMAL_ROLES } from '@app/types/bruker';
+
+const INSTRUCTION = ENVIRONMENT.isProduction
+  ? 'Be din leder om å tildele deg nødvendige roller.'
+  : 'Tildel din testbruker nødvendige roller eller benytt en annen testbruker.';
 
 export const LandingPage = () => {
+  const { user } = useContext(StaticDataContext);
   const result = useLandingPagePath();
 
   if (result !== null) {
@@ -14,7 +25,29 @@ export const LandingPage = () => {
 
   return (
     <PageWrapper>
-      <ErrorMessage>Ingen tilganger funnet</ErrorMessage>
+      <Centered>
+        <Heading level="1" size="medium" spacing>
+          Velkommen til Kabal
+        </Heading>
+        <BodyShort spacing>Kabal sender deg automatisk til riktig side basert på rollene til brukeren din.</BodyShort>
+        <BodyShort spacing>
+          Siden du har endt opp her betyr det mest sannsynlig at brukeren din ikke har korrekte roller for å bruke
+          Kabal.
+        </BodyShort>
+        <RoleList title="Roller brukeren din har nå" roles={user.roller} variant="info-moderate" />
+        <RoleList
+          title="Følgende roller brukes av Kabal"
+          description={INSTRUCTION}
+          roles={ALL_NORMAL_ROLES.filter((r) => !user.roller.includes(r))}
+          variant="neutral-moderate"
+        />
+      </Centered>
     </PageWrapper>
   );
 };
+
+const Centered = styled.div`
+  margin: 0 auto;
+  width: fit-content;
+  max-width: 500px;
+`;

--- a/frontend/src/pages/landing-page/landing-page.tsx
+++ b/frontend/src/pages/landing-page/landing-page.tsx
@@ -1,11 +1,12 @@
 import { BodyShort, Heading } from '@navikt/ds-react';
-import { useContext } from 'react';
+import { useContext, useEffect } from 'react';
 import { Navigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 import { StaticDataContext } from '@app/components/app/static-data-context';
 import { RoleList } from '@app/components/role-list/role-list';
 import { ENVIRONMENT } from '@app/environment';
 import { useLandingPagePath } from '@app/hooks/use-landing-page-path';
+import { pushEvent } from '@app/observability';
 import { PageWrapper } from '@app/pages/page-wrapper';
 import { ALL_NORMAL_ROLES } from '@app/types/bruker';
 
@@ -17,7 +18,17 @@ export const LandingPage = () => {
   const { user } = useContext(StaticDataContext);
   const result = useLandingPagePath();
 
-  if (result !== null) {
+  const hasResult = result !== null;
+
+  useEffect(() => {
+    if (!hasResult) {
+      pushEvent('landing-page', {
+        userRoles: user.roller.toSorted().join(', '),
+      });
+    }
+  }, [hasResult, user.roller]);
+
+  if (hasResult) {
     const [path] = result;
 
     return <Navigate replace to={path} />;

--- a/frontend/src/types/bruker.ts
+++ b/frontend/src/types/bruker.ts
@@ -43,10 +43,31 @@ export enum Role {
   KABAL_TILGANGSSTYRING_EGEN_ENHET = 'KABAL_TILGANGSSTYRING_EGEN_ENHET',
   KABAL_FAGTEKSTREDIGERING = 'KABAL_FAGTEKSTREDIGERING',
   KABAL_MALTEKSTREDIGERING = 'KABAL_MALTEKSTREDIGERING',
-  KABAL_ADMIN = 'KABAL_ADMIN',
   KABAL_ROL = 'KABAL_ROL',
   KABAL_KROL = 'KABAL_KROL',
+  KABAL_ADMIN = 'KABAL_ADMIN',
+  STRENGT_FORTROLIG = 'STRENGT_FORTROLIG',
+  FORTROLIG = 'FORTROLIG',
+  EGEN_ANSATT = 'EGEN_ANSATT',
 }
+
+export const ROLE_NAMES: Record<Role, string> = {
+  [Role.KABAL_SAKSBEHANDLING]: 'Kabal saksbehandling',
+  [Role.KABAL_INNSYN_EGEN_ENHET]: 'Kabal innsyn egen enhet',
+  [Role.KABAL_OPPGAVESTYRING_ALLE_ENHETER]: 'Kabal oppgavestyring alle enheter',
+  [Role.KABAL_TILGANGSSTYRING_EGEN_ENHET]: 'Kabal tilgangsstyring egen enhet',
+  [Role.KABAL_FAGTEKSTREDIGERING]: 'Kabal fagtekstredigering',
+  [Role.KABAL_MALTEKSTREDIGERING]: 'Kabal maltekstredigering',
+  [Role.KABAL_ROL]: 'Kabal ROL',
+  [Role.KABAL_KROL]: 'Kabal KROL',
+  [Role.KABAL_ADMIN]: 'Kabal admin',
+  [Role.STRENGT_FORTROLIG]: 'Strengt fortrolig',
+  [Role.FORTROLIG]: 'Fortrolig',
+  [Role.EGEN_ANSATT]: 'Egen ansatt',
+};
+
+const ALL_ROLES = Object.values(Role);
+export const ALL_NORMAL_ROLES = ALL_ROLES.filter((r) => r !== Role.KABAL_ADMIN);
 
 export interface ISetCustomInfoParams {
   key: keyof Omit<ICustomUserInfo, 'anonymous'>;


### PR DESCRIPTION
Legger til tilgangsstyring på alle routes.
Viser hjelpsomme sider dersom bruker ikke har tilgang eller havner på landingssiden.

# Dev

## Mangler rolle
![dev-no-access](https://github.com/navikt/kabal/assets/3177301/0ec8207d-983c-4602-b85e-616a73f30709)

## Landingsside
![dev-landing](https://github.com/navikt/kabal/assets/3177301/40ef6ccc-4ad8-4ba1-a479-f1bf07e7ce3a)

# Prod

## Mangler rolle
![prod-no-access](https://github.com/navikt/kabal/assets/3177301/3f06ed84-abee-43c5-ad4f-ccf885172790)

## Landingsside
![prod-landing](https://github.com/navikt/kabal/assets/3177301/c7757006-6545-43e4-b0d8-273a8c788bc2)