### PR TITLE
Handle/ignore time in date only formatting

### DIFF
--- a/frontend/src/domain/date.ts
+++ b/frontend/src/domain/date.ts
@@ -71,19 +71,22 @@ export const isoTimeToPretty = (isoTime: ISOTime | null | undefined): prettyTime
 
 const _isoTimeToPretty = (isoTime: ISOTime): prettyTime => isoTime.split('.')[0]!;
 
-export const isoDateToPretty = (isoDate: ISODate | null | undefined): prettyDate | null => {
+/** Formats ISO date(time) as human readable. */
+export const isoDateToPretty = (isoDate: ISODate | ISODateTime | null | undefined): prettyDate | null => {
   if (isoDate === null || isoDate === undefined || isoDate.length === 0) {
     return null;
   }
 
-  if (!isoDateRegex.test(isoDate)) {
-    pushLog('Invalid ISO date', { context: { isoDate } });
-    console.warn('Invalid ISO date', isoDate);
+  const [date] = isoDate.split('T');
 
-    return null;
+  if (date !== undefined && isoDateRegex.test(date)) {
+    return _isoDateToPretty(date);
   }
 
-  return _isoDateToPretty(isoDate);
+  pushLog('Invalid ISO date', { context: { isoDate } });
+  console.warn('Invalid ISO date', isoDate);
+
+  return null;
 };
 
 const _isoDateToPretty = (isoDate: ISODate): prettyDate => isoDate.split('-').reverse().join('.');

--- a/frontend/src/types/oppgaver.ts
+++ b/frontend/src/types/oppgaver.ts
@@ -26,9 +26,18 @@ interface IOppgaveRowVenteperiode extends IVenteperiode {
 export interface IOppgave {
   /** Age in days. */
   ageKA: number;
+  /** Date
+   * @format yyyy-MM-dd
+   */
   avsluttetAvSaksbehandlerDate: DateString | null;
   fagsystemId: string;
+  /** Date
+   * @format yyyy-MM-dd
+   */
   frist: DateString | null;
+  /** Date
+   * @format yyyy-MM-dd
+   */
   varsletFrist: DateString | null;
   hjemmelIdList: string[];
   registreringshjemmelIdList: string[];
@@ -36,6 +45,9 @@ export interface IOppgave {
   isAvsluttetAvSaksbehandler: boolean;
   medunderskriver: IHelper;
   rol: IHelper;
+  /** Date
+   * @format yyyy-MM-dd
+   */
   mottatt: DateString;
   tildeltSaksbehandlerident: string | null;
   /** DateTime */
@@ -46,6 +58,9 @@ export interface IOppgave {
   sattPaaVent: IOppgaveRowVenteperiode | null;
   feilregistrert: DateString | null;
   saksnummer: string;
+  /** Date
+   * @format yyyy-MM-dd
+   */
   datoSendtTilTR: DateString | null;
   previousSaksbehandler: INavEmployee | null;
 }


### PR DESCRIPTION
FE uses modified as a date, even though it contains time as well. This causes FE to log malformed dates.