### PR TITLE
Prohibit race condition errors when generating forlenget behandlingst…

### DIFF
--- a/frontend/src/components/behandling/behandlingsdetaljer/forlenget-behandlingstid/modal.tsx
+++ b/frontend/src/components/behandling/behandlingsdetaljer/forlenget-behandlingstid/modal.tsx
@@ -35,7 +35,7 @@ export const VarsletFristModal = ({ oppgavebehandling, children, isOpen, onClose
   return (
     <Modal header={{ heading }} width="2000px" closeOnBackdropClick open={isOpen} onClose={onClose}>
       <Modal.Body className="flex h-[80vh] w-full gap-9">
-        <VStack width="754px" padding="1" overflowY="auto" flexShrink="0" gap="4">
+        <VStack width="780px" padding="1" overflowY="auto" flexShrink="0" gap="4">
           <VStack gap="4">
             {isOpen ? <TimesPreviouslyExtended /> : null}
             {isOpen ? <DoNotSendLetter /> : null}
@@ -54,7 +54,7 @@ export const VarsletFristModal = ({ oppgavebehandling, children, isOpen, onClose
           <Errors sections={error} />
         </VStack>
 
-        {isOpen ? <Pdf id={oppgaveId} /> : null}
+        {isOpen ? <Pdf id={oppgaveId} varsletFrist={varsletFrist} /> : null}
       </Modal.Body>
 
       <Modal.Footer>

--- a/frontend/src/components/behandling/behandlingsdetaljer/forlenget-behandlingstid/set-behandlingstid-date.tsx
+++ b/frontend/src/components/behandling/behandlingsdetaljer/forlenget-behandlingstid/set-behandlingstid-date.tsx
@@ -1,10 +1,11 @@
 import { MAX_MONTHS_FROM_TODAY } from '@app/components/behandling/behandlingsdetaljer/forlenget-behandlingstid/constants';
+import { validateDate } from '@app/components/behandling/behandlingsdetaljer/forlenget-behandlingstid/validate';
 import { CURRENT_YEAR_IN_CENTURY } from '@app/components/date-picker/constants';
 import { DatePicker } from '@app/components/date-picker/date-picker';
 import { useOppgave } from '@app/hooks/oppgavebehandling/use-oppgave';
 import { useSetBehandlingstidDateMutation } from '@app/redux-api/forlenget-behandlingstid';
 import { ErrorMessage, VStack } from '@navikt/ds-react';
-import { addDays, addMonths, isAfter } from 'date-fns';
+import { addDays, addMonths } from 'date-fns';
 
 interface Props {
   value: string | null;
@@ -32,15 +33,8 @@ export const SetBehandlingstidDate = ({ value, id, error, setError }: Props) => 
             return setError(undefined);
           }
 
-          if (data.varsletFrist !== null && !isAfter(new Date(date), new Date(data.varsletFrist))) {
-            return setError('Fristen kan ikke være før forrige varslet frist');
-          }
-
-          if (isAfter(new Date(date), addMonths(new Date(), MAX_MONTHS_FROM_TODAY))) {
-            return setError('Fristen kan ikke være mer enn fire måneder frem i tid');
-          }
-
-          setError(undefined);
+          const error = validateDate(date, data.varsletFrist);
+          setError(error);
         }}
         value={value}
         size="small"

--- a/frontend/src/components/behandling/behandlingsdetaljer/forlenget-behandlingstid/validate.test.ts
+++ b/frontend/src/components/behandling/behandlingsdetaljer/forlenget-behandlingstid/validate.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'bun:test';
+import { validateBehandlingstid } from '@app/components/behandling/behandlingsdetaljer/forlenget-behandlingstid/validate';
+import { ISO_FORMAT } from '@app/components/date-picker/constants';
+import type { IForlengetBehandlingstid } from '@app/redux-api/forlenget-behandlingstid';
+import { BehandlingstidUnitType } from '@app/types/svarbrev';
+import { addDays, addMonths, addWeeks, format, startOfDay } from 'date-fns';
+
+const createBehandlingstid = ({
+  varsletFrist = null,
+  varsletBehandlingstidUnitTypeId = WEEKS,
+  varsletBehandlingstidUnits = null,
+}: Partial<IForlengetBehandlingstid['behandlingstid']>): IForlengetBehandlingstid['behandlingstid'] => ({
+  varsletBehandlingstidUnitTypeId,
+  varsletBehandlingstidUnits,
+  varsletFrist,
+});
+
+const { MONTHS, WEEKS } = BehandlingstidUnitType;
+
+const NOW = startOfDay(new Date());
+
+describe('validate', () => {
+  describe('with no previous varslet first', () => {
+    it('should return undefined if varslet frist is 4 months from now', () => {
+      const varsletFrist = format(addMonths(NOW, 4), ISO_FORMAT);
+      const result = validateBehandlingstid(createBehandlingstid({ varsletFrist }), null);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return error string if varslet frist is more than 4 months from now', () => {
+      const varsletFrist = format(addDays(addMonths(NOW, 4), 1), ISO_FORMAT);
+      const result = validateBehandlingstid(createBehandlingstid({ varsletFrist }), null);
+
+      expect(result).toBe('Fristen kan ikke være mer enn fire måneder frem i tid');
+    });
+
+    it('should return undefined if added months is 4 months from now', () => {
+      const result = validateBehandlingstid(
+        createBehandlingstid({ varsletBehandlingstidUnits: 4, varsletBehandlingstidUnitTypeId: MONTHS }),
+        null,
+      );
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return error string if added months is 5 months from now', () => {
+      const result = validateBehandlingstid(
+        createBehandlingstid({ varsletBehandlingstidUnits: 5, varsletBehandlingstidUnitTypeId: MONTHS }),
+        null,
+      );
+
+      expect(result).toBe('Fristen kan ikke være mer enn fire måneder frem i tid');
+    });
+
+    it('should return undefined if added months is 17 weeks (just under 4 months) from now', () => {
+      const result = validateBehandlingstid(createBehandlingstid({ varsletBehandlingstidUnits: 17 }), null);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return error string if added months is 18 weeks (just over 4 months) from now', () => {
+      const result = validateBehandlingstid(createBehandlingstid({ varsletBehandlingstidUnits: 18 }), null);
+
+      expect(result).toBe('Fristen kan ikke være mer enn fire måneder frem i tid');
+    });
+
+    it('shoud not return error when units/varsletFrist is not yet set', () => {
+      const result = validateBehandlingstid(createBehandlingstid({}), null);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('with previous varslet first', () => {
+    it('should return undefined if varslet frist is after prev varslet frist and max 4 months from now', () => {
+      const prevVarsletFrist = format(addMonths(NOW, 3), ISO_FORMAT);
+      const varsletFrist = format(addMonths(NOW, 4), ISO_FORMAT);
+      const result = validateBehandlingstid(createBehandlingstid({ varsletFrist }), prevVarsletFrist);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return error string if varslet frist is before prev varslet frist', () => {
+      const prevVarsletFrist = format(addMonths(NOW, 3), ISO_FORMAT);
+      const varsletFrist = format(addMonths(NOW, 2), ISO_FORMAT);
+      const result = validateBehandlingstid(createBehandlingstid({ varsletFrist }), prevVarsletFrist);
+
+      expect(result).toBe('Ny frist må være senere enn forrige varslet frist');
+    });
+
+    it('should return error string if varslet frist is equal to prev varslet frist', () => {
+      const prevVarsletFrist = format(addMonths(NOW, 3), ISO_FORMAT);
+      const varsletFrist = format(addMonths(NOW, 3), ISO_FORMAT);
+      const result = validateBehandlingstid(createBehandlingstid({ varsletFrist }), prevVarsletFrist);
+
+      expect(result).toBe('Ny frist må være senere enn forrige varslet frist');
+    });
+
+    it('should return error string if varslet frist is after prev varslet frist, but more than 4 months from now', () => {
+      const prevVarsletFrist = format(addMonths(NOW, 3), ISO_FORMAT);
+      const varsletFrist = format(addDays(addMonths(NOW, 4), 1), ISO_FORMAT);
+      const result = validateBehandlingstid(createBehandlingstid({ varsletFrist }), prevVarsletFrist);
+
+      expect(result).toBe('Fristen kan ikke være mer enn fire måneder frem i tid');
+    });
+
+    it('should return undefined if added months is after prev varslet frist and max 4 months from now', () => {
+      const prevVarsletFrist = format(addMonths(NOW, 3), ISO_FORMAT);
+      const result = validateBehandlingstid(
+        createBehandlingstid({ varsletBehandlingstidUnits: 4, varsletBehandlingstidUnitTypeId: MONTHS }),
+        prevVarsletFrist,
+      );
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return error string if added months is before prev varslet frist', () => {
+      const prevVarsletFrist = format(addMonths(NOW, 3), ISO_FORMAT);
+      const result = validateBehandlingstid(
+        createBehandlingstid({ varsletBehandlingstidUnits: 2, varsletBehandlingstidUnitTypeId: MONTHS }),
+        prevVarsletFrist,
+      );
+
+      expect(result).toBe('Ny frist må være senere enn forrige varslet frist');
+    });
+
+    it('should return error string if added months is equal to prev varslet frist', () => {
+      const prevVarsletFrist = format(addMonths(NOW, 3), ISO_FORMAT);
+
+      const result = validateBehandlingstid(
+        createBehandlingstid({ varsletBehandlingstidUnits: 3, varsletBehandlingstidUnitTypeId: MONTHS }),
+        prevVarsletFrist,
+      );
+
+      expect(result).toBe('Ny frist må være senere enn forrige varslet frist');
+    });
+
+    it('should return error string if added months is after prev varslet frist, but more than 4 months from now', () => {
+      const prevVarsletFrist = format(addMonths(NOW, 3), ISO_FORMAT);
+      const result = validateBehandlingstid(
+        createBehandlingstid({ varsletBehandlingstidUnits: 5, varsletBehandlingstidUnitTypeId: MONTHS }),
+        prevVarsletFrist,
+      );
+
+      expect(result).toBe('Fristen kan ikke være mer enn fire måneder frem i tid');
+    });
+
+    it('should return undefined if added weeks is after prev varslet frist and max 4 months from now', () => {
+      const prevVarsletFrist = format(addWeeks(NOW, 3), ISO_FORMAT);
+      const result = validateBehandlingstid(createBehandlingstid({ varsletBehandlingstidUnits: 17 }), prevVarsletFrist);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return error string if added weeks is before prev varslet frist', () => {
+      const prevVarsletFrist = format(addWeeks(NOW, 17), ISO_FORMAT);
+      const result = validateBehandlingstid(createBehandlingstid({ varsletBehandlingstidUnits: 16 }), prevVarsletFrist);
+
+      expect(result).toBe('Ny frist må være senere enn forrige varslet frist');
+    });
+
+    it('should return error string if added weeks is equal to prev varslet frist', () => {
+      const prevVarsletFrist = format(addWeeks(NOW, 17), ISO_FORMAT);
+      const result = validateBehandlingstid(createBehandlingstid({ varsletBehandlingstidUnits: 17 }), prevVarsletFrist);
+
+      expect(result).toBe('Ny frist må være senere enn forrige varslet frist');
+    });
+
+    it('should return error string if added weeks is after prev varslet frist, but more than 4 months from now', () => {
+      const prevVarsletFrist = format(addWeeks(NOW, 17), ISO_FORMAT);
+      const result = validateBehandlingstid(createBehandlingstid({ varsletBehandlingstidUnits: 18 }), prevVarsletFrist);
+
+      expect(result).toBe('Fristen kan ikke være mer enn fire måneder frem i tid');
+    });
+  });
+});

--- a/frontend/src/components/behandling/behandlingsdetaljer/forlenget-behandlingstid/validate.ts
+++ b/frontend/src/components/behandling/behandlingsdetaljer/forlenget-behandlingstid/validate.ts
@@ -1,0 +1,77 @@
+import { MAX_MONTHS_FROM_TODAY } from '@app/components/behandling/behandlingsdetaljer/forlenget-behandlingstid/constants';
+import type { IForlengetBehandlingstid } from '@app/redux-api/forlenget-behandlingstid';
+import { BehandlingstidUnitType } from '@app/types/svarbrev';
+import { addMonths, addWeeks, isAfter, startOfDay } from 'date-fns';
+
+const NOW = startOfDay(new Date());
+const MAX_DATE = addMonths(NOW, MAX_MONTHS_FROM_TODAY);
+
+const NO_PREV_FRIST_ERROR = 'Fristen kan ikke være mer enn fire måneder frem i tid';
+const PREV_FRIST_ERROR = 'Ny frist må være senere enn forrige varslet frist';
+
+export const validateBehandlingstid = (
+  {
+    varsletBehandlingstidUnitTypeId,
+    varsletBehandlingstidUnits,
+    varsletFrist,
+  }: IForlengetBehandlingstid['behandlingstid'],
+  prevVarsletFrist: string | null,
+): string | undefined => {
+  if (varsletFrist !== null) {
+    return validateDate(varsletFrist, prevVarsletFrist);
+  }
+
+  if (varsletBehandlingstidUnits !== null) {
+    return validateUnits(varsletBehandlingstidUnits, varsletBehandlingstidUnitTypeId, prevVarsletFrist);
+  }
+
+  return undefined;
+};
+
+export const validateUnits = (
+  units: number | null,
+  typeId: BehandlingstidUnitType,
+  prevVarsletFrist: string | null,
+): string | undefined => {
+  if (units === null) {
+    return undefined;
+  }
+
+  if (prevVarsletFrist !== null) {
+    const prevVarsletFristDate = new Date(prevVarsletFrist);
+
+    if (typeId === BehandlingstidUnitType.WEEKS && !isAfter(addWeeks(NOW, units), prevVarsletFristDate)) {
+      return PREV_FRIST_ERROR;
+    }
+
+    if (typeId === BehandlingstidUnitType.MONTHS && !isAfter(addMonths(NOW, units), prevVarsletFristDate)) {
+      return PREV_FRIST_ERROR;
+    }
+  }
+
+  if (typeId === BehandlingstidUnitType.WEEKS && isAfter(addWeeks(NOW, units), MAX_DATE)) {
+    return NO_PREV_FRIST_ERROR;
+  }
+
+  if (typeId === BehandlingstidUnitType.MONTHS && isAfter(addMonths(NOW, units), MAX_DATE)) {
+    return NO_PREV_FRIST_ERROR;
+  }
+
+  return undefined;
+};
+
+export const validateDate = (varsletFrist: string | null, prevVarsletFrist: string | null): string | undefined => {
+  if (varsletFrist === null) {
+    return undefined;
+  }
+
+  if (prevVarsletFrist !== null && !isAfter(new Date(varsletFrist), new Date(prevVarsletFrist))) {
+    return PREV_FRIST_ERROR;
+  }
+
+  if (isAfter(new Date(varsletFrist), MAX_DATE)) {
+    return NO_PREV_FRIST_ERROR;
+  }
+
+  return undefined;
+};


### PR DESCRIPTION
…id PDF:

- Don't do optimistic update on required fields that are default null (they have their own local state, so UI still feels snappy)
- Unify validation
- Make room for potential error messages