### PR TITLE
Prevent § from turning into &sect; on backspace

### DIFF
--- a/frontend/src/plate/plugins/autoformat/rules.ts
+++ b/frontend/src/plate/plugins/autoformat/rules.ts
@@ -1,10 +1,4 @@
-import {
-  autoformatArrow,
-  autoformatLegal,
-  autoformatLegalHtml,
-  autoformatMath,
-  autoformatPunctuation,
-} from '@platejs/autoformat';
+import { autoformatArrow, autoformatLegal, autoformatMath, autoformatPunctuation } from '@platejs/autoformat';
 import { autoformatBlocks } from '@/plate/plugins/autoformat/blocks';
 import { autoformatLists } from '@/plate/plugins/autoformat/lists';
 import { autoformatMarks } from '@/plate/plugins/autoformat/marks';
@@ -18,7 +12,6 @@ export const autoformatRules: EditorAutoformatRule[] = [
   ...autoformatMarks,
   ...(autoformatPunctuation as EditorAutoformatRule[]),
   ...(autoformatLegal as EditorAutoformatRule[]),
-  ...(autoformatLegalHtml as EditorAutoformatRule[]),
   ...(autoformatArrow as EditorAutoformatRule[]),
   ...(autoformatMath as EditorAutoformatRule[]),
 ];


### PR DESCRIPTION
`autoformatLegalHtml` gjør følgende konverteringer:

- `&trade;` til ™
- `&reg;` til ®
- `&copy;` til ©
- `&sect;` til §

Ingen av disse skal forekomme i kopiert tekst.
Ingen skriver disse for hånd.
Bare § er relevant for oss.

Problemet er at den også gjør disse konverteringene i revers, som forårsaker at § blir til `&sect;` ved backspace.

Har forsøkt å kopiere fra Lovdata og Wikipedia, man får ikke `&sect;` i clipboard, alltid §.