### PR TITLE
KROL: Add ROL task management similar to OPPGAVESTYRING

### DIFF
--- a/frontend/src/components/common-table-components/open.tsx
+++ b/frontend/src/components/common-table-components/open.tsx
@@ -28,8 +28,8 @@ export const OpenForRoleAccess = ({
   ...buttonProps
 }: RoleAccessedProps) => {
   const isMerkantil = useHasRole(Role.KABAL_OPPGAVESTYRING_ALLE_ENHETER);
-  const { user } = useContext(StaticDataContext);
   const isKrol = useHasRole(Role.KABAL_KROL);
+  const { user } = useContext(StaticDataContext);
 
   const canOpen =
     isMerkantil ||

--- a/frontend/src/components/common-table-components/oppgave-rows/oppgave-row.tsx
+++ b/frontend/src/components/common-table-components/oppgave-rows/oppgave-row.tsx
@@ -20,6 +20,7 @@ import { ColumnKeyEnum } from '@/components/common-table-components/types';
 import { Ytelse } from '@/components/common-table-components/ytelse';
 import { CopyButton } from '@/components/copy-button/copy-button';
 import { Feilregistrert } from '@/components/feilregistrering/feilregistrert';
+import { KrolStyring } from '@/components/krolstyring/krolstyring';
 import { Oppgavestyring } from '@/components/oppgavestyring/oppgavestyring';
 // biome-ignore lint/suspicious/noImportCycles: See relevant-oppgaver.tsx for more information about this dependency cycle.
 import { RelevantOppgaver } from '@/components/relevant-oppgaver/relevant-oppgaver';
@@ -167,7 +168,7 @@ const getColumns = (columnKeys: ColumnKeyEnum[], oppgave: IOppgave) =>
       case ColumnKeyEnum.Rol:
         return (
           <Table.DataCell key={key}>
-            <Rol oppgaveId={oppgave.id} rolIdent={oppgave.rol.employee?.navIdent ?? null} />
+            <Rol {...oppgave} />
           </Table.DataCell>
         );
       case ColumnKeyEnum.Open:
@@ -191,6 +192,13 @@ const getColumns = (columnKeys: ColumnKeyEnum[], oppgave: IOppgave) =>
         return (
           <Table.DataCell key={key}>
             <Oppgavestyring {...oppgave} />
+          </Table.DataCell>
+        );
+      case ColumnKeyEnum.KrolStyring:
+      case ColumnKeyEnum.KrolStyringNonFilterable:
+        return (
+          <Table.DataCell key={key}>
+            <KrolStyring {...oppgave} />
           </Table.DataCell>
         );
       case ColumnKeyEnum.TildelingWithFilter:

--- a/frontend/src/components/common-table-components/oppgave-table/oppgave-table-headers.tsx
+++ b/frontend/src/components/common-table-components/oppgave-table/oppgave-table-headers.tsx
@@ -124,6 +124,7 @@ export const TableFilterHeaders = ({ columnKeys, tableKey, ...sortProps }: Props
           </Returnert>
         );
       case ColumnKeyEnum.Rol:
+      case ColumnKeyEnum.KrolStyring:
         return <Rol key={key} columnKey={key} tableKey={tableKey} />;
       case ColumnKeyEnum.PaaVentReason:
         return <PaaVentReasons key={key} columnKey={key} tableKey={tableKey} />;
@@ -137,6 +138,7 @@ export const TableFilterHeaders = ({ columnKeys, tableKey, ...sortProps }: Props
       case ColumnKeyEnum.OpenWithYtelseAccess:
       case ColumnKeyEnum.Tildeling:
       case ColumnKeyEnum.OppgavestyringNonFilterable:
+      case ColumnKeyEnum.KrolStyringNonFilterable:
       case ColumnKeyEnum.Utfall:
       case ColumnKeyEnum.Feilregistrert:
       case ColumnKeyEnum.Saksnummer:

--- a/frontend/src/components/common-table-components/rol.tsx
+++ b/frontend/src/components/common-table-components/rol.tsx
@@ -7,11 +7,7 @@ import type { Entry } from '@/components/searchable-select/virtualized-option-li
 import { useHasRole } from '@/hooks/use-has-role';
 import { useGetPotentialRolQuery } from '@/redux-api/oppgaver/queries/behandling/behandling';
 import { type INavEmployee, Role } from '@/types/bruker';
-
-interface Props {
-  oppgaveId: string;
-  rolIdent: string | null;
-}
+import type { IOppgave } from '@/types/oppgaver';
 
 const NONE_LABEL = 'Felles kø';
 const NONE_ENTRY: Entry<INavEmployee | null> = {
@@ -22,13 +18,15 @@ const NONE_ENTRY: Entry<INavEmployee | null> = {
 };
 const EMPTY_LIST: INavEmployee[] = [];
 
-export const Rol = ({ oppgaveId, rolIdent }: Props) => {
-  const { data, isLoading } = useGetPotentialRolQuery(oppgaveId);
+export const Rol = ({ id, rol }: IOppgave) => {
+  const { employee, flowState } = rol;
+  const rolIdent = employee?.navIdent ?? null;
+  const { data, isLoading } = useGetPotentialRolQuery(id);
   const hasAccess = useHasRole(Role.KABAL_KROL);
 
   const rols = data === undefined ? EMPTY_LIST : data.rols;
 
-  const { onChange, isUpdating } = useSetRol(oppgaveId, rols);
+  const { onChange, isUpdating } = useSetRol(id, rols, flowState);
 
   const options = useMemo((): Entry<INavEmployee | null>[] => [NONE_ENTRY, ...rols.map(toNavEmployeeEntry)], [rols]);
 

--- a/frontend/src/components/common-table-components/types.ts
+++ b/frontend/src/components/common-table-components/types.ts
@@ -38,6 +38,8 @@ export enum ColumnKeyEnum {
   FlowStatesWithoutSelf = 37,
   FlowStatesWithSelf = 38,
   TypeForSakerITR = 39,
+  KrolStyring = 40,
+  KrolStyringNonFilterable = 41,
 }
 
 export const TABLE_HEADERS = {
@@ -80,4 +82,6 @@ export const TABLE_HEADERS = {
   [ColumnKeyEnum.AccessYtelser]: 'Ytelse',
   [ColumnKeyEnum.AccessInnsendingshjemler]: 'Hjemmel',
   [ColumnKeyEnum.AccessRegistreringshjemler]: 'Registreringshjemler',
+  [ColumnKeyEnum.KrolStyring]: 'Rådgivende overlege',
+  [ColumnKeyEnum.KrolStyringNonFilterable]: 'Rådgivende overlege',
 };

--- a/frontend/src/components/krolstyring/fradel-rol-button.tsx
+++ b/frontend/src/components/krolstyring/fradel-rol-button.tsx
@@ -1,0 +1,72 @@
+import { Button } from '@navikt/ds-react';
+import { ActionToast } from '@/components/toast/action-toast';
+import { toast } from '@/components/toast/store';
+import { useHasRole } from '@/hooks/use-has-role';
+import { useSetRolMutation } from '@/redux-api/oppgaver/mutations/set-rol';
+import { Role } from '@/types/bruker';
+import { FlowState } from '@/types/oppgave-common';
+import type { IOppgave } from '@/types/oppgaver';
+
+export const FradelRolButton = ({ id, rol }: Pick<IOppgave, 'id' | 'rol'>) => {
+  const hasKrolAccess = useHasRole(Role.KABAL_KROL);
+  const [setRol, { isLoading }] = useSetRolMutation();
+
+  if (!hasKrolAccess || rol.flowState !== FlowState.SENT || rol.employee === null) {
+    return null;
+  }
+
+  const rolEmployee = rol.employee;
+
+  const tildel = async () => {
+    try {
+      await setRol({ employee: rolEmployee, oppgaveId: id }).unwrap();
+      toast.success(
+        <ActionToast secondary={UndoTildelAction} attrs={{ 'data-oppgaveid': id }}>
+          Oppgave tildelt på nytt
+        </ActionToast>,
+      );
+    } catch {
+      // Error already handled in RTKQ file.
+    }
+  };
+
+  const fradel = async () => {
+    try {
+      await setRol({ employee: null, oppgaveId: id }).unwrap();
+      toast.success(
+        <ActionToast secondary={UndoFradelAction} attrs={{ 'data-oppgaveid': id }}>
+          Oppgave lagt i felles kø
+        </ActionToast>,
+      );
+    } catch {
+      // Error already handled in RTKQ file.
+    }
+  };
+
+  const UndoTildelAction = (
+    <Button data-color="neutral" size="small" variant="secondary" onClick={fradel}>
+      Angre
+    </Button>
+  );
+
+  const UndoFradelAction = (
+    <Button data-color="neutral" size="small" variant="secondary" onClick={tildel}>
+      Angre
+    </Button>
+  );
+
+  return (
+    <Button
+      data-color="neutral"
+      variant="secondary"
+      size="small"
+      loading={isLoading}
+      disabled={isLoading}
+      data-klagebehandlingid={id}
+      onClick={fradel}
+      className="whitespace-nowrap [grid-area:tildel]"
+    >
+      Legg i felles kø
+    </Button>
+  );
+};

--- a/frontend/src/components/krolstyring/krolstyring.tsx
+++ b/frontend/src/components/krolstyring/krolstyring.tsx
@@ -1,0 +1,15 @@
+import { HGrid, HStack } from '@navikt/ds-react';
+import { Rol } from '@/components/common-table-components/rol';
+import { FradelRolButton } from '@/components/krolstyring/fradel-rol-button';
+import { TildelRolButton } from '@/components/krolstyring/tildel-rol-button';
+import type { IOppgave } from '@/types/oppgaver';
+
+export const KrolStyring = (oppgave: IOppgave) => (
+  <HGrid columns="110px 400px" gap="space-0 space-8" style={{ gridTemplateAreas: '"tildel rol"' }}>
+    <TildelRolButton {...oppgave} />
+    <FradelRolButton id={oppgave.id} rol={oppgave.rol} />
+    <HStack align="center" justify="start" height="34px" width="100%" className="[grid-area:rol]">
+      <Rol {...oppgave} />
+    </HStack>
+  </HGrid>
+);

--- a/frontend/src/components/krolstyring/tildel-rol-button.tsx
+++ b/frontend/src/components/krolstyring/tildel-rol-button.tsx
@@ -1,0 +1,84 @@
+import { Button } from '@navikt/ds-react';
+import { useContext } from 'react';
+import { StaticDataContext } from '@/components/app/static-data-context';
+import { OpenForRoleAccess } from '@/components/common-table-components/open';
+import { ActionToast } from '@/components/toast/action-toast';
+import { toast } from '@/components/toast/store';
+import { useHasRole } from '@/hooks/use-has-role';
+import { useSetRolMutation } from '@/redux-api/oppgaver/mutations/set-rol';
+import { Role } from '@/types/bruker';
+import { FlowState } from '@/types/oppgave-common';
+import type { IOppgave } from '@/types/oppgaver';
+
+export const TildelRolButton = ({ id, rol, medunderskriver, tildeltSaksbehandlerident }: IOppgave) => {
+  const { user } = useContext(StaticDataContext);
+  const { navIdent, navn } = user;
+  const isRol = useHasRole(Role.KABAL_ROL);
+  const [setRol, { isLoading }] = useSetRolMutation();
+
+  if (!isRol || rol.flowState !== FlowState.SENT || rol.employee !== null) {
+    return null;
+  }
+
+  const fradel = async () => {
+    try {
+      await setRol({ employee: null, oppgaveId: id }).unwrap();
+      toast.success(
+        <ActionToast secondary={UndoFradelAction} attrs={{ 'data-oppgaveid': id }}>
+          Oppgave lagt i felles kø
+        </ActionToast>,
+      );
+    } catch {
+      // Error already handled in RTKQ file.
+    }
+  };
+
+  const UndoTildelButton = (
+    <Button data-color="neutral" size="small" variant="secondary" onClick={fradel}>
+      Angre
+    </Button>
+  );
+
+  const OpenButton = (
+    <OpenForRoleAccess
+      id={id}
+      tildeltSaksbehandlerident={tildeltSaksbehandlerident}
+      medunderskriverident={medunderskriver.employee?.navIdent ?? null}
+      rol={rol}
+    />
+  );
+
+  const tildel = async () => {
+    try {
+      await setRol({ employee: { navIdent, navn }, oppgaveId: id }).unwrap();
+      toast.success(
+        <ActionToast secondary={UndoTildelButton} primary={OpenButton} attrs={{ 'data-oppgaveid': id }}>
+          Oppgave tildelt
+        </ActionToast>,
+      );
+    } catch {
+      // Error already handled in RTKQ file.
+    }
+  };
+
+  const UndoFradelAction = (
+    <Button data-color="neutral" size="small" variant="secondary" onClick={tildel}>
+      Angre
+    </Button>
+  );
+
+  return (
+    <Button
+      data-color="neutral"
+      variant="secondary"
+      size="small"
+      loading={isLoading}
+      disabled={isLoading}
+      data-klagebehandlingid={id}
+      onClick={tildel}
+      className="whitespace-nowrap [grid-area:tildel]"
+    >
+      Tildel meg
+    </Button>
+  );
+};

--- a/frontend/src/components/oppgavestyring/use-set-rol.tsx
+++ b/frontend/src/components/oppgavestyring/use-set-rol.tsx
@@ -10,7 +10,11 @@ import { useSetRolFlowStateMutation } from '@/redux-api/oppgaver/mutations/set-r
 import type { INavEmployee } from '@/types/bruker';
 import { FlowState } from '@/types/oppgave-common';
 
-export const useSetRol = (oppgaveId: string, rol: INavEmployee[] = EMPTY_MEDUNDERSKRIVERE): Return => {
+export const useSetRol = (
+  oppgaveId: string,
+  rol: INavEmployee[] = EMPTY_MEDUNDERSKRIVERE,
+  flowState?: FlowState,
+): Return => {
   const [setRol, { isLoading: isSettingEmployee }] = useSetRolMutation({
     fixedCacheKey: getFixedCacheKey(oppgaveId),
   });
@@ -28,7 +32,9 @@ export const useSetRol = (oppgaveId: string, rol: INavEmployee[] = EMPTY_MEDUNDE
         const { modified } = await setRol({ oppgaveId, employee: toROL }).unwrap();
         const timestamp = parseISO(modified).getTime();
 
-        await setRolState({ oppgaveId, flowState: FlowState.SENT }).unwrap();
+        if (flowState !== FlowState.SENT) {
+          await setRolState({ oppgaveId, flowState: FlowState.SENT }).unwrap();
+        }
 
         successToast({
           oppgaveId,
@@ -43,7 +49,7 @@ export const useSetRol = (oppgaveId: string, rol: INavEmployee[] = EMPTY_MEDUNDE
         // Error already handled in RTKQ file.
       }
     },
-    [rol, oppgaveId, setRol, setRolState],
+    [rol, oppgaveId, setRol, setRolState, flowState],
   );
 
   onChangeRef.current = onChange;

--- a/frontend/src/components/rol-tables/ledige-rol-oppgaver-table.tsx
+++ b/frontend/src/components/rol-tables/ledige-rol-oppgaver-table.tsx
@@ -5,7 +5,7 @@ import { OppgaveTableKey } from '@/components/common-table-components/oppgave-ta
 import { ColumnKeyEnum } from '@/components/common-table-components/types';
 import { SectionWithHeading } from '@/components/section-with-heading/section-with-heading';
 import { OppgaveTableRowsPerPage } from '@/hooks/settings/use-setting';
-import { useHasRole } from '@/hooks/use-has-role';
+import { useHasAnyOfRoles } from '@/hooks/use-has-role';
 import { useGetSettingsQuery } from '@/redux-api/bruker';
 import { useGetLedigeRolOppgaverQuery } from '@/redux-api/oppgaver/queries/oppgaver';
 import { Role } from '@/types/bruker';
@@ -18,20 +18,25 @@ const COLUMNS: ColumnKeyEnum[] = [
   ColumnKeyEnum.Age,
   ColumnKeyEnum.Deadline,
   ColumnKeyEnum.VarsletFrist,
-  ColumnKeyEnum.RolTildeling,
+  ColumnKeyEnum.Open,
+  ColumnKeyEnum.KrolStyringNonFilterable,
 ];
 
-export const LedigeRolOppgaverTable = () => {
-  const hasAccess = useHasRole(Role.KABAL_ROL);
+interface Props {
+  heading?: string;
+}
+
+export const LedigeRolOppgaverTable = ({ heading = 'Ledige oppgaver' }: Props) => {
+  const hasAccess = useHasAnyOfRoles([Role.KABAL_ROL, Role.KABAL_KROL]);
 
   if (!hasAccess) {
     return null;
   }
 
-  return <LedigeOppgaverTableInternal />;
+  return <LedigeOppgaverTableInternal heading={heading} />;
 };
 
-const LedigeOppgaverTableInternal = (): React.JSX.Element => {
+const LedigeOppgaverTableInternal = ({ heading }: Required<Props>): React.JSX.Element => {
   const params = useOppgaveTableState(OppgaveTableKey.ROL_LEDIGE, SortFieldEnum.FRIST, SortOrderEnum.ASC);
 
   const {
@@ -49,7 +54,7 @@ const LedigeOppgaverTableInternal = (): React.JSX.Element => {
   });
 
   return (
-    <SectionWithHeading heading="Ledige oppgaver" size="small" level="1">
+    <SectionWithHeading heading={heading} size="small" level="1">
       <OppgaveTable
         zebraStripes
         columns={COLUMNS}

--- a/frontend/src/components/rol/under-arbeid-table.tsx
+++ b/frontend/src/components/rol/under-arbeid-table.tsx
@@ -21,8 +21,8 @@ const COLUMNS: ColumnKeyEnum[] = [
   ColumnKeyEnum.Age,
   ColumnKeyEnum.Deadline,
   ColumnKeyEnum.VarsletFrist,
-  ColumnKeyEnum.Rol,
   ColumnKeyEnum.Open,
+  ColumnKeyEnum.KrolStyring,
 ];
 
 export const RolOppgaverTable = () => {

--- a/frontend/src/pages/oppgavestyring/oppgavestyring.tsx
+++ b/frontend/src/pages/oppgavestyring/oppgavestyring.tsx
@@ -5,6 +5,7 @@ import { EnhetensOppgaverPaaVentTable } from '@/components/enhetens-oppgaver-paa
 import { EnhetensOppgaverTable } from '@/components/enhetens-oppgaver-table/enhetens-oppgaver-table';
 import { ReturnerteRolOppgaverTable } from '@/components/rol/returnerte-table';
 import { RolOppgaverTable } from '@/components/rol/under-arbeid-table';
+import { LedigeRolOppgaverTable } from '@/components/rol-tables/ledige-rol-oppgaver-table';
 import { OppgaverPageWrapper } from '@/pages/page-wrapper';
 
 export const OppgavestyringPage = () => {
@@ -13,11 +14,15 @@ export const OppgavestyringPage = () => {
   return (
     <OppgaverPageWrapper title={`Oppgavestyring - ${user.ansattEnhet.navn}`}>
       <EnhetensOppgaverTable />
-      <RolOppgaverTable />
 
       <EnhetensOppgaverPaaVentTable />
 
       <EnhetensFerdigstilteOppgaverTable />
+
+      <RolOppgaverTable />
+
+      <LedigeRolOppgaverTable heading="Felles kø" />
+
       <ReturnerteRolOppgaverTable />
     </OppgaverPageWrapper>
   );


### PR DESCRIPTION
Users with the KROL role can now assign ROL users to cases from both "Ledige oppgaver" and "Tildelte oppgaver" on the oppgavestyring page, mirroring how OPPGAVESTYRING manages saksbehandlere.

- New KrolStyring component: searchable ROL select and "Legg i felles kø" button for KABAL_KROL; "Tildel meg" button for KABAL_ROL users in the same column
- RolOppgaverTable (tildelte): replaces Rol column with KrolStyring
- LedigeRolOppgaverTable: now accessible to KABAL_KROL and uses KrolStyringNonFilterable; added to the oppgavestyring page
- ROL tables grouped at the bottom of the oppgavestyring page